### PR TITLE
chore: fix the build

### DIFF
--- a/apps/nextjs/pages/index.tsx
+++ b/apps/nextjs/pages/index.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import '@propeldata/wc-time-series'
 
 const IndexPage = () => (

--- a/apps/nextjs/pages/netflix.tsx
+++ b/apps/nextjs/pages/netflix.tsx
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import '@propeldata/wc-time-series'
 import Image from 'next/image'
 

--- a/apps/vanilla/src/main.ts
+++ b/apps/vanilla/src/main.ts
@@ -1,4 +1,3 @@
-// @ts-nocheck
 import '@propeldata/wc-time-series'
 
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `

--- a/packages/time-series/lib/time-series.ts
+++ b/packages/time-series/lib/time-series.ts
@@ -64,21 +64,21 @@ export class TimeSeries extends LitElement {
    * Metric unique name
    */
   @property()
-  metric: string = ''
+  metric = ''
 
   /**
    * Relative time range that the chart
    * will respond to
    */
   @property()
-  relativeTimeRange: string = 'LAST_30_DAYS'
+  relativeTimeRange = 'LAST_30_DAYS'
 
   /**
    * Granularity that the chart
    * will respond to
    */
   @property()
-  granularity: string = 'DAY'
+  granularity = 'DAY'
 
   /**
    * If passed along with `values`, the component
@@ -99,7 +99,7 @@ export class TimeSeries extends LitElement {
    * to customer's app credentials
    */
   @property()
-  accessToken: string = ''
+  accessToken = ''
 
   /**
    * Basic styles initial state
@@ -143,7 +143,7 @@ export class TimeSeries extends LitElement {
     Chart.defaults.font.style = this.styles.font?.style
     Chart.defaults.font.lineHeight = this.styles.font?.lineHeight
 
-    new Chart(this._root, {
+    const options = {
       type: 'bar',
       responsive: true,
       data: {
@@ -160,15 +160,13 @@ export class TimeSeries extends LitElement {
           }
         ]
       },
-      // @ts-ignore
       plugins: [customCanvasBackgroundColor],
       options: {
         plugins: {
-          // @ts-ignore
           customCanvasBackgroundColor: {
             color: this.styles.canvas?.backgroundColor
           }
-        },
+        } as any,
         layout: {
           padding: this.styles.canvas?.padding
         },
@@ -179,7 +177,7 @@ export class TimeSeries extends LitElement {
             },
             beginAtZero: true,
             ticks: {
-              callback: (_value, index) => {
+              callback: (_: any, index: number) => {
                 const labelDate = new Date(this.labels[index])
                 const month = labelDate.getUTCMonth() + 1
                 const day = labelDate.getUTCDate()
@@ -190,7 +188,9 @@ export class TimeSeries extends LitElement {
           }
         }
       }
-    })
+    } as any
+
+    new Chart(this._root, options)
 
     this._root.style.borderRadius = this.styles.canvas?.borderRadius as string
   }
@@ -226,6 +226,12 @@ export class TimeSeries extends LitElement {
 }
 
 declare global {
+  // eslint-disable-next-line
+  namespace JSX {
+    interface IntrinsicElements {
+      'time-series': any
+    }
+  }
   interface HTMLElementTagNameMap {
     'time-series': TimeSeries
   }


### PR DESCRIPTION
This PR fixes the build in two ways.

**1. Fix `yarn build`**

If you ran `yarn build`, you would see the following error:

```
$ yarn build --force
• Packages in scope: @propeldata/nextjs, @propeldata/vanilla, @propeldata/wc-plugins, @propeldata/wc-time-series
• Running build in 4 packages
• Remote caching disabled
@propeldata/wc-plugins:build: cache bypass, force executing 5be517b40f911f40
@propeldata/wc-time-series:build: cache bypass, force executing 3c13bf2dc42721fc
@propeldata/nextjs:build: cache bypass, force executing 8dc5dcde6219ec41
@propeldata/vanilla:build: cache bypass, force executing 9067e6aef5913eab
@propeldata/nextjs:build: info  - Checking validity of types...
@propeldata/vanilla:build: vite v3.2.4 building for production...
@propeldata/vanilla:build: transforming...
@propeldata/vanilla:build: ✓ 82 modules transformed.
@propeldata/vanilla:build: rendering chunks...
@propeldata/vanilla:build: dist/index.html                 0.38 KiB
@propeldata/vanilla:build: dist/assets/index.babfb840.js   249.01 KiB / gzip: 82.35 KiB
@propeldata/nextjs:build: warn  - The Next.js plugin was not detected in your ESLint configuration. See https://nextjs.org/docs/basic-features/eslint#migrating-existing-config
@propeldata/nextjs:build: 
@propeldata/nextjs:build: Failed to compile.
@propeldata/nextjs:build: 
@propeldata/nextjs:build: ./pages/index.tsx
@propeldata/nextjs:build: 1:1  Error: Do not use "@ts-nocheck" because it alters compilation errors.  @typescript-eslint/ban-ts-comment
@propeldata/nextjs:build: 
@propeldata/nextjs:build: ./pages/netflix.tsx
@propeldata/nextjs:build: 1:1  Error: Do not use "@ts-nocheck" because it alters compilation errors.  @typescript-eslint/ban-ts-comment
@propeldata/nextjs:build: 
@propeldata/nextjs:build: info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/basic-features/eslint#disabling-rules
@propeldata/nextjs:build: ERROR: command finished with error: command (/Users/mark/src/propel/web-components/apps/nextjs) yarn run build exited (1)
command (/Users/mark/src/propel/web-components/apps/nextjs) yarn run build exited (1)

 Tasks:    3 successful, 4 total
Cached:    0 cached, 4 total
  Time:    6.965s 

 ERROR  run failed: command  exited (1)
```

To fix this, I got rid of "@ts-nocheck" everywhere and added

```typescript
// eslint-disable-next-line
namespace JSX {
  interface IntrinsicElements {
    'time-series': any
  }
}
```

to the `declare global` block inside of `time-series.ts`. I did this based on [this blog post](https://goulet.dev/posts/consuming-web-component-react-typescript/). Using `any` isn't great, so we should come back to this and see if lit can help.

**2. Fix `eslint`**

There is an `eslint` pre-commit hook setup that was failing as follows:

```
$ git commit
✔ Preparing lint-staged...
❯ Running tasks for staged files...
  ❯ package.json — 4 files
    ❯ **/*.{js,jsx,ts,tsx} — 4 files
      ✖ eslint --fix [FAILED]
      ◼ prettier --write
    ↓ **/*.{css,md,json,graphql} — no files [SKIPPED]
↓ Skipped because of errors from tasks. [SKIPPED]
✔ Reverting to original state because of errors...
✔ Cleaning up temporary files...

✖ eslint --fix:

/Users/mark/src/propel/web-components/apps/vanilla/src/main.ts
  3:1  warning  Forbidden non-null assertion  @typescript-eslint/no-non-null-assertion

/Users/mark/src/propel/web-components/packages/time-series/lib/time-series.ts
  163:7   error    Do not use "@ts-ignore" because it alters compilation errors  @typescript-eslint/ban-ts-comment
  167:11  error    Do not use "@ts-ignore" because it alters compilation errors  @typescript-eslint/ban-ts-comment
  229:3   error    ES2015 module syntax is preferred over namespaces             @typescript-eslint/no-namespace
  231:22  warning  Unexpected any. Specify a different type                      @typescript-eslint/no-explicit-any

✖ 5 problems (3 errors, 2 warnings)

husky - pre-commit hook exited with code 1 (error)
```

This is because of issues with the Chart.js TypeScript types. I don't know how to fix this right now, so I just cast to `any`. Not great. Maybe we can revisit it.