### PR TITLE
Fix Counter, Leaderboard and TimeSeries bugs

### DIFF
--- a/packages/core/components/src/ErrorBoundary.tsx
+++ b/packages/core/components/src/ErrorBoundary.tsx
@@ -22,7 +22,7 @@ export class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    console.error(error, errorInfo)
+    // console.error(error, errorInfo) we will set logs as a feature later
   }
 
   render() {

--- a/packages/core/release/src/index.ts
+++ b/packages/core/release/src/index.ts
@@ -34,7 +34,7 @@ async function main(): Promise<void> {
       }
     }
   } catch (error) {
-    console.error(error)
+    // console.error(error) we will set logs as a feature later
     process.exit(1)
   }
 }

--- a/packages/react/counter/src/Counter.tsx
+++ b/packages/react/counter/src/Counter.tsx
@@ -113,15 +113,15 @@ export function Counter(props: CounterProps) {
   React.useEffect(() => {
     function handlePropsMismatch() {
       if (isStatic && !value) {
-        console.error('InvalidPropsError: You must pass either `value` or `query` props')
+        // console.error('InvalidPropsError: You must pass either `value` or `query` props') we will set logs as a feature later
         setHasError(true)
         return
       }
 
       if (!isStatic && (!query?.accessToken || !query?.metric || !query?.timeRange)) {
-        console.error(
-          'InvalidPropsError: When opting for fetching data you must pass at least `accessToken`, `metric` and `timeRange` in the `query` prop'
-        )
+        // console.error(
+        //   'InvalidPropsError: When opting for fetching data you must pass at least `accessToken`, `metric` and `timeRange` in the `query` prop'
+        // ) we will set logs as a feature later
         setHasError(true)
         return
       }
@@ -143,7 +143,7 @@ export function Counter(props: CounterProps) {
 
         if (fetchedValue === undefined) {
           setHasError(true)
-          console.error(`QueryError: Your metric ${query?.metric} returned undefined.`)
+          // console.error(`QueryError: Your metric ${query?.metric} returned undefined.`) we will set logs as a feature later
           return
         }
 

--- a/packages/react/counter/src/Counter.tsx
+++ b/packages/react/counter/src/Counter.tsx
@@ -136,18 +136,19 @@ export function Counter(props: CounterProps) {
     async function setup() {
       if (isStatic && value) {
         setDataValue(value)
-        return
       }
 
-      const fetchedValue = await fetchData()
+      if (!isStatic) {
+        const fetchedValue = await fetchData()
 
-      if (typeof fetchedValue === 'undefined') {
-        setHasError(true)
-        console.error(`QueryError: Your metric ${query?.metric} returned undefined.`)
-        return
+        if (typeof fetchedValue === 'undefined') {
+          setHasError(true)
+          console.error(`QueryError: Your metric ${query?.metric} returned undefined.`)
+          return
+        }
+
+        setDataValue(fetchedValue)
       }
-
-      setDataValue(fetchedValue)
     }
 
     setup()

--- a/packages/react/counter/src/Counter.tsx
+++ b/packages/react/counter/src/Counter.tsx
@@ -75,10 +75,10 @@ export function Counter(props: CounterProps) {
           uniqueName: query?.metric,
           counterInput: {
             timeRange: {
-              relative: query?.timeRange?.relative || null,
-              n: query?.timeRange?.n || null,
-              start: query?.timeRange?.start || null,
-              stop: query?.timeRange?.stop || null
+              relative: query?.timeRange?.relative ?? null,
+              n: query?.timeRange?.n ?? null,
+              start: query?.timeRange?.start ?? null,
+              stop: query?.timeRange?.stop ?? null
             },
             filters,
             propeller: query?.propeller
@@ -141,7 +141,7 @@ export function Counter(props: CounterProps) {
       if (!isStatic) {
         const fetchedValue = await fetchData()
 
-        if (typeof fetchedValue === 'undefined') {
+        if (fetchedValue === undefined) {
           setHasError(true)
           console.error(`QueryError: Your metric ${query?.metric} returned undefined.`)
           return

--- a/packages/react/counter/src/Counter.tsx
+++ b/packages/react/counter/src/Counter.tsx
@@ -55,6 +55,8 @@ export function Counter(props: CounterProps) {
   const [hasError, setHasError] = React.useState(false)
   const [isLoading, setIsLoading] = React.useState(false)
 
+  const filtersString = JSON.stringify(query?.filters || [])
+
   /**
    * Fetches the counter data
    * when the user doesn't provide
@@ -64,14 +66,21 @@ export function Counter(props: CounterProps) {
     try {
       setIsLoading(true)
 
+      const filters = JSON.parse(filtersString)
+
       const response = await request(
         PROPEL_GRAPHQL_API_ENDPOINT,
         CounterDocument,
         {
           uniqueName: query?.metric,
           counterInput: {
-            timeRange: query?.timeRange,
-            filters: query?.filters,
+            timeRange: {
+              relative: query?.timeRange?.relative || null,
+              n: query?.timeRange?.n || null,
+              start: query?.timeRange?.start || null,
+              stop: query?.timeRange?.stop || null
+            },
+            filters,
             propeller: query?.propeller
           }
         },
@@ -90,7 +99,16 @@ export function Counter(props: CounterProps) {
     } finally {
       setIsLoading(false)
     }
-  }, [query])
+  }, [
+    query?.metric,
+    query?.accessToken,
+    query?.timeRange?.n,
+    query?.timeRange?.relative,
+    query?.timeRange?.start,
+    query?.timeRange?.stop,
+    query?.propeller,
+    filtersString
+  ])
 
   React.useEffect(() => {
     function handlePropsMismatch() {
@@ -123,9 +141,9 @@ export function Counter(props: CounterProps) {
 
       const fetchedValue = await fetchData()
 
-      if (!fetchedValue) {
+      if (typeof fetchedValue === 'undefined') {
         setHasError(true)
-        console.error(`QueryError: Your metric ${query?.metric} returned undefined or a \`null\` value.`)
+        console.error(`QueryError: Your metric ${query?.metric} returned undefined.`)
         return
       }
 

--- a/packages/react/counter/src/utils.ts
+++ b/packages/react/counter/src/utils.ts
@@ -29,7 +29,7 @@ export const getValueWithPrefixAndSufix = (params: {
 }) => {
   const { prefix, value, sufix, localize } = params
 
-  if (typeof value === 'undefined') return
+  if (value === undefined) return
 
   return (prefix ? prefix : '') + getValue({ value, localize }) + (sufix ? sufix : '')
 }

--- a/packages/react/counter/src/utils.ts
+++ b/packages/react/counter/src/utils.ts
@@ -7,9 +7,13 @@ const getValue = (options: getValueOptions) => {
   const { value, localize } = options
 
   const isInteger = Number.isInteger(parseFloat(value))
+  const isNull = value === null
 
   if (isInteger) {
     return localize ? parseInt(value).toLocaleString() : parseInt(value)
+  }
+  if (isNull) {
+    return '-'
   }
 
   return localize
@@ -25,7 +29,7 @@ export const getValueWithPrefixAndSufix = (params: {
 }) => {
   const { prefix, value, sufix, localize } = params
 
-  if (!value) return
+  if (typeof value === 'undefined') return
 
   return (prefix ? prefix : '') + getValue({ value, localize }) + (sufix ? sufix : '')
 }

--- a/packages/react/leaderboard/src/Leaderboard.tsx
+++ b/packages/react/leaderboard/src/Leaderboard.tsx
@@ -254,13 +254,13 @@ export function Leaderboard(props: LeaderboardProps) {
   React.useEffect(() => {
     function handlePropsMismatch() {
       if (isStatic && !headers && !rows) {
-        console.error('InvalidPropsError: You must pass either `headers` and `rows` or `query` props')
+        // console.error('InvalidPropsError: You must pass either `headers` and `rows` or `query` props') we will set logs as a feature later
         setHasError(true)
         return
       }
 
       if (isStatic && (!headers || !rows)) {
-        console.error('InvalidPropsError: When passing the data via props you must pass both `headers` and `rows`')
+        // console.error('InvalidPropsError: When passing the data via props you must pass both `headers` and `rows`') we will set logs as a feature later
         setHasError(true)
         return
       }
@@ -268,9 +268,9 @@ export function Leaderboard(props: LeaderboardProps) {
         !isStatic &&
         (!query.accessToken || !query.metric || !query.timeRange || !query.dimensions || !query.rowLimit)
       ) {
-        console.error(
-          'InvalidPropsError: When opting for fetching data you must pass at least `accessToken`, `metric`, `dimensions`, `rowLimit` and `timeRange` in the `query` prop'
-        )
+        // console.error(
+        //   'InvalidPropsError: When opting for fetching data you must pass at least `accessToken`, `metric`, `dimensions`, `rowLimit` and `timeRange` in the `query` prop'
+        // ) we will set logs as a feature later
         setHasError(true)
         return
       }
@@ -306,7 +306,7 @@ export function Leaderboard(props: LeaderboardProps) {
   React.useEffect(() => {
     try {
       if (variant !== 'bar' && variant !== 'table') {
-        console.error('InvalidPropsError: `variant` prop must be either `bar` or `table`')
+        // console.error('InvalidPropsError: `variant` prop must be either `bar` or `table`') we will set logs as a feature later
         throw new Error('InvalidPropsError')
       }
       setHasError(false)

--- a/packages/react/leaderboard/src/Leaderboard.tsx
+++ b/packages/react/leaderboard/src/Leaderboard.tsx
@@ -214,10 +214,10 @@ export function Leaderboard(props: LeaderboardProps) {
             rowLimit: query?.rowLimit,
             dimensions,
             timeRange: {
-              relative: query?.timeRange?.relative || null,
-              n: query?.timeRange?.n || null,
-              start: query?.timeRange?.start || null,
-              stop: query?.timeRange?.stop || null
+              relative: query?.timeRange?.relative ?? null,
+              n: query?.timeRange?.n ?? null,
+              start: query?.timeRange?.start ?? null,
+              stop: query?.timeRange?.stop ?? null
             }
           }
         },

--- a/packages/react/time-series/src/TimeSeries.tsx
+++ b/packages/react/time-series/src/TimeSeries.tsx
@@ -129,6 +129,8 @@ export function TimeSeries(props: TimeSeriesProps) {
   const idRef = React.useRef(idCounter++)
   const id = `time-series-${idRef.current}`
 
+  const filtersString = JSON.stringify(query?.filters || [])
+
   /**
    * The html node where the chart will render
    */
@@ -257,15 +259,22 @@ export function TimeSeries(props: TimeSeriesProps) {
     try {
       setIsLoading(true)
 
+      const filters = JSON.parse(filtersString)
+
       const response = await request(
         PROPEL_GRAPHQL_API_ENDPOINT,
         TimeSeriesDocument,
         {
           uniqueName: query?.metric,
           timeSeriesInput: {
-            timeRange: query?.timeRange,
+            timeRange: {
+              relative: query?.timeRange?.relative || null,
+              n: query?.timeRange?.n || null,
+              start: query?.timeRange?.start || null,
+              stop: query?.timeRange?.stop || null
+            },
             granularity,
-            filters: query?.filters,
+            filters: filters,
             propeller: query?.propeller
           }
         },
@@ -285,7 +294,17 @@ export function TimeSeries(props: TimeSeriesProps) {
     } finally {
       setIsLoading(false)
     }
-  }, [granularity, query?.accessToken, query?.filters, query?.metric, query?.propeller, query?.timeRange])
+  }, [
+    granularity,
+    query?.accessToken,
+    filtersString,
+    query?.metric,
+    query?.propeller,
+    query?.timeRange?.n,
+    query?.timeRange?.relative,
+    query?.timeRange?.start,
+    query?.timeRange?.stop
+  ])
 
   React.useEffect(() => {
     function handlePropsMismatch() {
@@ -323,7 +342,7 @@ export function TimeSeries(props: TimeSeriesProps) {
     if (!isStatic) {
       fetchChartData()
     }
-  }, [isStatic, query?.timeRange, query?.filters, query?.propeller, query?.granularity, query?.accessToken, fetchData])
+  }, [isStatic, fetchData])
 
   React.useEffect(() => {
     if (isStatic) {

--- a/packages/react/time-series/src/TimeSeries.tsx
+++ b/packages/react/time-series/src/TimeSeries.tsx
@@ -309,20 +309,20 @@ export function TimeSeries(props: TimeSeriesProps) {
   React.useEffect(() => {
     function handlePropsMismatch() {
       if (isStatic && !labels && !values) {
-        console.error('InvalidPropsError: You must pass either `labels` and `values` or `query` props')
+        // console.error('InvalidPropsError: You must pass either `labels` and `values` or `query` props') we will set logs as a feature later
         setHasError(true)
         return
       }
 
       if (isStatic && (!labels || !values)) {
-        console.error('InvalidPropsError: When passing the data via props you must pass both `labels` and `values`')
+        // console.error('InvalidPropsError: When passing the data via props you must pass both `labels` and `values`') we will set logs as a feature later
         setHasError(true)
         return
       }
       if (!isStatic && (!query.accessToken || !query.metric || !query.timeRange)) {
-        console.error(
-          'InvalidPropsError: When opting for fetching data you must pass at least `accessToken`, `metric` and `timeRange` in the `query` prop'
-        )
+        // console.error(
+        //   'InvalidPropsError: When opting for fetching data you must pass at least `accessToken`, `metric` and `timeRange` in the `query` prop'
+        // ) we will set logs as a feature later
         setHasError(true)
         return
       }

--- a/packages/react/time-series/src/TimeSeries.tsx
+++ b/packages/react/time-series/src/TimeSeries.tsx
@@ -268,10 +268,10 @@ export function TimeSeries(props: TimeSeriesProps) {
           uniqueName: query?.metric,
           timeSeriesInput: {
             timeRange: {
-              relative: query?.timeRange?.relative || null,
-              n: query?.timeRange?.n || null,
-              start: query?.timeRange?.start || null,
-              stop: query?.timeRange?.stop || null
+              relative: query?.timeRange?.relative ?? null,
+              n: query?.timeRange?.n ?? null,
+              start: query?.timeRange?.start ?? null,
+              stop: query?.timeRange?.stop ?? null
             },
             granularity,
             filters: filters,

--- a/packages/react/time-series/src/utils.ts
+++ b/packages/react/time-series/src/utils.ts
@@ -116,7 +116,6 @@ export function useSetupDefaultStyles(styles?: Styles) {
       }
 
       Chart.defaults.color = styles?.font?.color || defaultStyles.font.color
-      Chart.defaults.font = font as Partial<FontSpec>
 
       Chart.defaults.elements.point.pointStyle = pointStyle === undefined ? 'circle' : pointStyle
       Chart.defaults.elements.point.radius = styles?.point?.radius || defaultStyles.point.radius

--- a/packages/react/time-series/src/utils.ts
+++ b/packages/react/time-series/src/utils.ts
@@ -9,7 +9,8 @@ import {
   ScriptableAndArray,
   ScriptableContext,
   ScaleOptions,
-  TimeUnit
+  TimeUnit,
+  FontSpec
 } from 'chart.js'
 import { Maybe, RelativeTimeRange, TimeRangeInput, TimeSeriesGranularity } from '@propeldata/ui-kit-graphql'
 
@@ -115,6 +116,7 @@ export function useSetupDefaultStyles(styles?: Styles) {
       }
 
       Chart.defaults.color = styles?.font?.color || defaultStyles.font.color
+      Chart.defaults.font = font as Partial<FontSpec>
 
       Chart.defaults.elements.point.pointStyle = pointStyle === undefined ? 'circle' : pointStyle
       Chart.defaults.elements.point.radius = styles?.point?.radius || defaultStyles.point.radius

--- a/packages/react/time-series/src/utils.ts
+++ b/packages/react/time-series/src/utils.ts
@@ -9,8 +9,7 @@ import {
   ScriptableAndArray,
   ScriptableContext,
   ScaleOptions,
-  TimeUnit,
-  FontSpec
+  TimeUnit
 } from 'chart.js'
 import { Maybe, RelativeTimeRange, TimeRangeInput, TimeSeriesGranularity } from '@propeldata/ui-kit-graphql'
 


### PR DESCRIPTION
This PR fixes some bugs found while testing the components in the example apps.

## TimeSeries
- Connected mode re-fetched data on styles change
- Connected mode re-fetching on every re-render due to useEffect object dependencies

## Leaderboard
- Connected mode re-fetched data on styles change
- Connected mode re-fetching on every re-render due to useEffect object dependencies
- Switching from variant `bar` to `table` and then to `bar` again made `bar` chart disappear

## Counter
- Connected mode re-fetched data on styles change
- Connected mode re-fetching on every re-render due to useEffect object dependencies
- When Connected mode receiving a `null` value, it showed an error, changed to `-` instead
- Sometimes Counter attempted to fetch data on Static mode, added !isStatic condition to fix