### PR TITLE
Add `type` yAxis prop to allow logarithmic scale

### DIFF
--- a/app/examples/react-18/src/components/TimeSeriesStaticTest.jsx
+++ b/app/examples/react-18/src/components/TimeSeriesStaticTest.jsx
@@ -71,7 +71,7 @@ export function TimeSeriesStaticTest() {
           point: { style: pointStyle },
           yAxis: {
             beginAtZero: true,
-            type: 'logarithmic'
+            scale: 'logarithmic'
           }
         }}
       />

--- a/app/examples/react-18/src/components/TimeSeriesStaticTest.jsx
+++ b/app/examples/react-18/src/components/TimeSeriesStaticTest.jsx
@@ -31,28 +31,15 @@ const mockData1 = {
 
 const mockData2 = {
   labels: [
-    '01/02',
-    '02/02',
-    '03/02',
-    '04/02',
-    '05/02',
-    '06/02',
-    '07/02',
-    '08/02',
-    '09/02',
-    '10/02',
-    '11/02',
-    '12/02',
-    '13/02',
-    '14/02',
-    '15/02',
-    '16/02',
-    '17/02',
-    '18/02',
-    '19/02',
-    '20/02'
+    '2023-05-11T00:00:00.000Z',
+    '2023-05-12T00:00:00.000Z',
+    '2023-05-13T00:00:00.000Z',
+    '2023-05-14T00:00:00.000Z',
+    '2023-05-15T00:00:00.000Z',
+    '2023-05-16T00:00:00.000Z',
+    '2023-05-17T00:00:00.000Z'
   ],
-  values: [809, 984, 673, 500, 522, 471, 872, 578, 123, 619, 38, 326, 128, 11, 844, 58, 576, 28, 663, 189]
+  values: [0, 200, 300, 400, 79187691, 248679, 131034]
 }
 
 export function TimeSeriesStaticTest() {
@@ -81,7 +68,11 @@ export function TimeSeriesStaticTest() {
         styles={{
           bar: { backgroundColor: barsColor },
           canvas: { backgroundColor: '#f5f5f5' },
-          point: { style: pointStyle }
+          point: { style: pointStyle },
+          yAxis: {
+            beginAtZero: true,
+            type: 'logarithmic'
+          }
         }}
       />
       <div className="flex items-center gap-2">

--- a/packages/react/time-series/README.md
+++ b/packages/react/time-series/README.md
@@ -188,6 +188,7 @@ The `styles` prop allows you to customize the appearance of the chart. It accept
 
 ## yAxis Styles
 
-| Name        | Type      | Default | Description                                     |
-| ----------- | --------- | ------- | ----------------------------------------------- |
-| beginAtZero | `boolean` | `false` | Whether the y axis should begin at zero or not. |
+| Name        | Type                          | Default    | Description                                     |
+| ----------- | ----------------------------- | ---------- | ----------------------------------------------- |
+| beginAtZero | `boolean`                     | `false`    | Whether the y axis should begin at zero or not. |
+| type        | `"linear"` or `"logarithmic"` | `"linear"` | Type of scale for the y axis                    |

--- a/packages/react/time-series/README.md
+++ b/packages/react/time-series/README.md
@@ -191,4 +191,4 @@ The `styles` prop allows you to customize the appearance of the chart. It accept
 | Name        | Type                          | Default    | Description                                     |
 | ----------- | ----------------------------- | ---------- | ----------------------------------------------- |
 | beginAtZero | `boolean`                     | `false`    | Whether the y axis should begin at zero or not. |
-| type        | `"linear"` or `"logarithmic"` | `"linear"` | Type of scale for the y axis                    |
+| scale       | `"linear"` or `"logarithmic"` | `"linear"` | The scale of the y axis.                        |

--- a/packages/react/time-series/src/defaults.ts
+++ b/packages/react/time-series/src/defaults.ts
@@ -54,7 +54,8 @@ export const defaultStyles = {
     hoverBackgroundColor: '#000'
   },
   yAxis: {
-    beginAtZero: false
+    beginAtZero: false,
+    type: 'linear'
   }
 }
 

--- a/packages/react/time-series/src/defaults.ts
+++ b/packages/react/time-series/src/defaults.ts
@@ -55,7 +55,7 @@ export const defaultStyles = {
   },
   yAxis: {
     beginAtZero: false,
-    type: 'linear'
+    scale: 'linear'
   }
 }
 

--- a/packages/react/time-series/src/types.ts
+++ b/packages/react/time-series/src/types.ts
@@ -1,3 +1,13 @@
+import type { ScaleOptionsByType } from 'chart.js'
+
+export type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>
+    }
+  : T
+
+export type ChartScales = Partial<{ [key: string]: ScaleOptionsByType<'linear' | 'logarithmic'> }>
+
 export type ChartVariant = 'bar' | 'line'
 
 export type TimeSeriesData = {
@@ -78,5 +88,6 @@ export type Styles = {
   }
   yAxis?: {
     beginAtZero?: boolean
+    type?: 'linear' | 'logarithmic'
   }
 }

--- a/packages/react/time-series/src/types.ts
+++ b/packages/react/time-series/src/types.ts
@@ -1,11 +1,5 @@
 import type { ScaleOptionsByType } from 'chart.js'
 
-export type DeepPartial<T> = T extends object
-  ? {
-      [P in keyof T]?: DeepPartial<T[P]>
-    }
-  : T
-
 export type ChartScales = Partial<{ [key: string]: ScaleOptionsByType<'linear' | 'logarithmic'> }>
 
 export type ChartVariant = 'bar' | 'line'

--- a/packages/react/time-series/src/types.ts
+++ b/packages/react/time-series/src/types.ts
@@ -88,6 +88,6 @@ export type Styles = {
   }
   yAxis?: {
     beginAtZero?: boolean
-    type?: 'linear' | 'logarithmic'
+    scale?: 'linear' | 'logarithmic'
   }
 }

--- a/packages/react/time-series/src/utils.ts
+++ b/packages/react/time-series/src/utils.ts
@@ -264,12 +264,16 @@ export function getScales(options: GetScalesOptions) {
 
   const currentFormatScales = isFormatted || isStatic ? customFormatScales : autoFormatScales
 
-  const linearScales: DeepPartial<{ [key: string]: ScaleOptionsByType<'linear'> }> = {
-    ...currentFormatScales,
-    y: {
-      ...currentFormatScales.y,
-      type: 'linear'
+  if (scale === 'linear') {
+    const linearScales: DeepPartial<{ [key: string]: ScaleOptionsByType<'linear'> }> = {
+      ...currentFormatScales,
+      y: {
+        ...currentFormatScales.y,
+        type: 'linear'
+      }
     }
+
+    return linearScales
   }
 
   const logarithmicScales: DeepPartial<{ [key: string]: ScaleOptionsByType<'logarithmic'> }> = {
@@ -280,12 +284,5 @@ export function getScales(options: GetScalesOptions) {
     }
   }
 
-  return {
-    linear: {
-      ...linearScales
-    },
-    logarithmic: {
-      ...logarithmicScales
-    }
-  }[scale] as ChartScales
+  return logarithmicScales
 }

--- a/packages/react/time-series/src/utils.ts
+++ b/packages/react/time-series/src/utils.ts
@@ -227,7 +227,7 @@ interface GetScalesOptions {
 
 export function getScales(options: GetScalesOptions) {
   const { styles, granularity, isFormatted, isStatic } = options
-  const type = styles?.yAxis?.type || defaultStyles.yAxis.type
+  const scale = styles?.yAxis?.scale || defaultStyles.yAxis.scale
 
   const hideGridLines = styles?.canvas?.hideGridLines || defaultStyles.canvas.hideGridLines
 
@@ -286,5 +286,5 @@ export function getScales(options: GetScalesOptions) {
     logarithmic: {
       ...logarithmicScales
     }
-  }[type] as ChartScales
+  }[scale] as ChartScales
 }

--- a/packages/react/time-series/src/utils.ts
+++ b/packages/react/time-series/src/utils.ts
@@ -11,9 +11,10 @@ import {
   TimeUnit,
   ScaleOptionsByType
 } from 'chart.js'
+import type { DeepPartial } from 'chart.js/dist/types/utils'
 import { Maybe, RelativeTimeRange, TimeRangeInput, TimeSeriesGranularity } from '@propeldata/ui-kit-graphql'
 
-import { ChartPlugins, ChartVariant, DeepPartial, Styles, ChartScales } from './types'
+import { ChartPlugins, ChartVariant, Styles, ChartScales } from './types'
 import { defaultStyles } from './defaults'
 
 export function cssvar(name: string) {


### PR DESCRIPTION
This PR adds a `type` prop to the `styles` api in order to allow setting the y scale type to `logarithmic`