### PR TITLE
feat: new release process

### DIFF
--- a/.github/workflows/publish-pre-release.yml
+++ b/.github/workflows/publish-pre-release.yml
@@ -1,0 +1,58 @@
+name: publish-pre-release
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  PROPELDATA_CI_TOKEN: ${{ secrets.PROPELDATA_CI_TOKEN }}
+
+jobs:
+  publish:
+    if: github.event.head_commit.message != 'release'
+    runs-on: ubuntu-latest
+    steps:
+      # Setup
+      - uses: actions/checkout@v3
+        with:
+          # so that when we push tags, workflows are released, which does not happen with the default token
+          token: ${{ secrets.PROPELDATA_CI_TOKEN }}
+          # NOTE(mroberts): https://github.com/actions/checkout/issues/217
+          fetch-depth: '0'
+      - uses: actions/checkout@v3
+        with:
+          repository: propeldata/actions
+          token: ${{ secrets.PROPELDATA_CI_TOKEN }}
+          path: actions
+      - uses: ./actions/propel-slack
+        with:
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          slack_signing_secret: ${{ secrets.SLACK_SIGNING_SECRET }}
+          message_type: 'pipeline'
+      - uses: ./actions/propel-slack
+        with:
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          slack_signing_secret: ${{ secrets.SLACK_SIGNING_SECRET }}
+          message_type: 'publish'
+
+      # Build
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.13.0'
+      - uses: ./actions/propel-slack
+        with:
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          slack_signing_secret: ${{ secrets.SLACK_SIGNING_SECRET }}
+          message_type: 'build'
+      - uses: ./.github/actions/prepare
+        with:
+          cache_fresh_start: 'true'
+      - run: yarn build
+
+      # Release
+      - run: |
+          yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
+          git config --global user.email "engineering@propeldata.com"
+          git config --global user.name "Propel Data Cloud, Inc." 
+          COMMIT_MESSAGE=release PRE_RELEASE=true yarn release

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,15 +1,12 @@
-name: publish
+name: publish-release
 
-on:
-  push:
-    branches:
-      - main
+on: workflow_dispatch
+
 env:
   PROPELDATA_CI_TOKEN: ${{ secrets.PROPELDATA_CI_TOKEN }}
 
 jobs:
   publish:
-    if: github.event.head_commit.message != 'release'
     runs-on: ubuntu-latest
     steps:
       # Setup

--- a/app/examples/react-16/package.json
+++ b/app/examples/react-16/package.json
@@ -1,5 +1,6 @@
 {
   "name": "react-16",
+  "private": true,
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start"
   },

--- a/app/examples/react-17/package.json
+++ b/app/examples/react-17/package.json
@@ -1,5 +1,6 @@
 {
   "name": "react-17",
+  "private": true,
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start"
   },

--- a/app/examples/react-18/package.json
+++ b/app/examples/react-18/package.json
@@ -1,5 +1,6 @@
 {
   "name": "react-18",
+  "private": true,
   "scripts": {
     "start": "DISABLE_ESLINT_PLUGIN=true react-scripts start"
   },

--- a/app/storybook/package.json
+++ b/app/storybook/package.json
@@ -1,5 +1,6 @@
 {
   "name": "ui-kit-storybook",
+  "private": true,
   "packageManager": "yarn@3.3.0",
   "dependencies": {
     "@propeldata/react-counter": "workspace:^",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@typescript-eslint/parser": "^5.43.0",
     "babel-loader": "^8.3.0",
     "commitizen": "^4.2.5",
+    "conventional-changelog-angular": "^6.0.0",
     "cz-conventional-changelog": "^3.3.0",
     "eslint": "^8.28.0",
     "eslint-config-prettier": "^8.5.0",

--- a/packages/core/components/package.json
+++ b/packages/core/components/package.json
@@ -11,7 +11,8 @@
     "build": "parcel build"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "group": "@propeldata/ui-kit"
   },
   "devDependencies": {
     "parcel": "^2.8.2",

--- a/packages/core/graphql/package.json
+++ b/packages/core/graphql/package.json
@@ -12,7 +12,8 @@
     "gen": "graphql-codegen --config codegen.yml"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "group": "@propeldata/ui-kit"
   },
   "dependencies": {
     "dotenv": "^16.0.3",

--- a/packages/core/plugins/package.json
+++ b/packages/core/plugins/package.json
@@ -15,7 +15,8 @@
     "src"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "group": "@propeldata/ui-kit"
   },
   "devDependencies": {
     "parcel": "^2.8.2",

--- a/packages/core/release/package.json
+++ b/packages/core/release/package.json
@@ -19,14 +19,16 @@
     "bin",
     "lib"
   ],
+  "peerDependencies": {
+    "conventional-changelog-angular": "^6.0.0"
+  },
   "devDependencies": {
     "@tsconfig/node18": "1.0.1",
     "eslint": "^8.32.0",
     "typescript": "^4.9.4"
   },
   "dependencies": {
-    "@monodeploy/node": "^3.6.0",
-    "@monodeploy/types": "^3.6.0",
-    "conventional-changelog-angular": "^5.0.13"
+    "@monodeploy/node": "^4.0.1",
+    "@monodeploy/types": "^4.0.1"
   }
 }

--- a/packages/core/release/src/index.ts
+++ b/packages/core/release/src/index.ts
@@ -8,13 +8,19 @@ import { execSync } from 'child_process'
 async function main(): Promise<void> {
   try {
     const autoCommitMessage = process.env.COMMIT_MESSAGE
+    const dryRun = process.env.DRY_RUN === 'true'
+    const prerelease = process.env.PRE_RELEASE === 'true'
+
     const config: RecursivePartial<MonodeployConfiguration> = {
       access: 'infer',
       autoCommit: true,
       autoCommitMessage,
       commitIgnorePatterns: [autoCommitMessage ?? 'chore: release \\[skip ci\\]'],
       conventionalChangelogConfig: 'conventional-changelog-angular',
+      dryRun,
       persistVersions: true,
+      prerelease,
+      packageGroupManifestField: 'publishConfig.group',
       topologicalDev: true
     }
 
@@ -24,13 +30,30 @@ async function main(): Promise<void> {
     // push them individually.
 
     const branch = getBranch()
-    execSync(`git push origin ${branch}`)
+    if (!dryRun) {
+      execSync(`git push origin ${branch}`)
+    } else {
+      console.log(`[Dry Run] git push origin ${branch}`)
+    }
 
+    // NOTE(mroberts): With package groups, the same tag could be generated
+    // multiple times, so we need to dedupe them.
+
+    const tags = new Set<string>()
     for (const packageName in changeset) {
       const change = changeset[packageName]
       const { tag } = change
+
       if (tag !== null) {
+        tags.add(tag)
+      }
+    }
+
+    for (const tag of tags) {
+      if (!dryRun) {
         execSync(`git push origin refs/tags/${tag}`)
+      } else {
+        console.log(`[Dry Run] git push origin refs/tags/${tag}`)
       }
     }
   } catch (error) {

--- a/packages/react/counter/package.json
+++ b/packages/react/counter/package.json
@@ -11,7 +11,8 @@
     "build": "parcel build"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "group": "@propeldata/ui-kit"
   },
   "dependencies": {
     "@emotion/css": "^11.10.5",

--- a/packages/react/leaderboard/package.json
+++ b/packages/react/leaderboard/package.json
@@ -11,7 +11,8 @@
     "build": "parcel build"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "group": "@propeldata/ui-kit"
   },
   "dependencies": {
     "@emotion/css": "^11.10.5",

--- a/packages/react/time-series/package.json
+++ b/packages/react/time-series/package.json
@@ -11,7 +11,8 @@
     "build": "parcel build"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "group": "@propeldata/ui-kit"
   },
   "dependencies": {
     "@emotion/css": "^11.10.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2251,10 +2251,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/eslintrc@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "@eslint/eslintrc@npm:2.0.3::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40eslint%2Feslintrc%2F-%2Feslintrc-2.0.3.tgz"
+  dependencies:
+    ajv: ^6.12.4
+    debug: ^4.3.2
+    espree: ^9.5.2
+    globals: ^13.19.0
+    ignore: ^5.2.0
+    import-fresh: ^3.2.1
+    js-yaml: ^4.1.0
+    minimatch: ^3.1.2
+    strip-json-comments: ^3.1.1
+  checksum: ddc51f25f8524d8231db9c9bf03177e503d941a332e8d5ce3b10b09241be4d5584a378a529a27a527586bfbccf3031ae539eb891352033c340b012b4d0c81d92
+  languageName: node
+  linkType: hard
+
 "@eslint/js@npm:8.38.0":
   version: 8.38.0
   resolution: "@eslint/js@npm:8.38.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40eslint%2Fjs%2F-%2Fjs-8.38.0.tgz"
   checksum: 1f28987aa8c9cd93e23384e16c7220863b39b5dc4b66e46d7cdbccce868040f455a98d24cd8b567a884f26545a0555b761f7328d4a00c051e7ef689cbea5fce1
+  languageName: node
+  linkType: hard
+
+"@eslint/js@npm:8.42.0":
+  version: 8.42.0
+  resolution: "@eslint/js@npm:8.42.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40eslint%2Fjs%2F-%2Fjs-8.42.0.tgz"
+  checksum: 750558843ac458f7da666122083ee05306fc087ecc1e5b21e7e14e23885775af6c55bcc92283dff1862b7b0d8863ec676c0f18c7faf1219c722fe91a8ece56b6
   languageName: node
   linkType: hard
 
@@ -2837,6 +2861,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@humanwhocodes/config-array@npm:^0.11.10":
+  version: 0.11.10
+  resolution: "@humanwhocodes/config-array@npm:0.11.10::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40humanwhocodes%2Fconfig-array%2F-%2Fconfig-array-0.11.10.tgz"
+  dependencies:
+    "@humanwhocodes/object-schema": ^1.2.1
+    debug: ^4.1.1
+    minimatch: ^3.0.5
+  checksum: 1b1302e2403d0e35bc43e66d67a2b36b0ad1119efc704b5faff68c41f791a052355b010fb2d27ef022670f550de24cd6d08d5ecf0821c16326b7dcd0ee5d5d8a
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.11.8":
   version: 0.11.8
   resolution: "@humanwhocodes/config-array@npm:0.11.8::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40humanwhocodes%2Fconfig-array%2F-%2Fconfig-array-0.11.8.tgz"
@@ -3370,149 +3405,149 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@monodeploy/changelog@npm:^3.9.0":
-  version: 3.9.0
-  resolution: "@monodeploy/changelog@npm:3.9.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40monodeploy%2Fchangelog%2F-%2Fchangelog-3.9.0.tgz"
+"@monodeploy/changelog@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@monodeploy/changelog@npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40monodeploy%2Fchangelog%2F-%2Fchangelog-4.0.1.tgz"
   dependencies:
     conventional-changelog-writer: ^5.0.1
     conventional-commits-parser: ^3.2.4
     p-limit: ^3.1.0
   peerDependencies:
-    "@monodeploy/git": ^3.9.0
-    "@monodeploy/io": ^3.9.0
-    "@monodeploy/logging": ^3.8.0
-    "@monodeploy/types": ^3.9.0
-    "@yarnpkg/core": ^3.5.0
-    "@yarnpkg/fslib": ^2.10.2
-  checksum: cb90d09ec14090fdfebe04f81ec9f7b3e2f608ab11ba1aaf524cb80353714c9af9d19a156bc930580940a78b1a1b36e6e4fbad5582717ee44a8bbc10d75ae0ae
+    "@monodeploy/git": ^4.0.1
+    "@monodeploy/io": ^4.0.1
+    "@monodeploy/logging": ^4.0.1
+    "@monodeploy/types": ^4.0.1
+    "@yarnpkg/core": ^3.5.1
+    "@yarnpkg/fslib": ^2.10.3
+  checksum: c31661106507c39d24a94c141d5dae5a973f3848a27f0aeea25642d7acfa61e127af4783eb895b04f238ede51d04d9d6439824b428c4b8965fcd3213b913d78c
   languageName: node
   linkType: hard
 
-"@monodeploy/dependencies@npm:^3.9.0":
-  version: 3.9.0
-  resolution: "@monodeploy/dependencies@npm:3.9.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40monodeploy%2Fdependencies%2F-%2Fdependencies-3.9.0.tgz"
+"@monodeploy/dependencies@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@monodeploy/dependencies@npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40monodeploy%2Fdependencies%2F-%2Fdependencies-4.0.1.tgz"
   peerDependencies:
-    "@monodeploy/logging": ^3.8.0
-    "@monodeploy/types": ^3.9.0
-    "@yarnpkg/core": ^3.5.0
-  checksum: 2f058c121303f903e98acc59677aeed572cce81a89a8ae0901271e7562404fd9df543699a8c827059195679c95fad0a918fc595faa85d6e6a27d71caa05c47a3
+    "@monodeploy/logging": ^4.0.1
+    "@monodeploy/types": ^4.0.1
+    "@yarnpkg/core": ^3.5.1
+  checksum: c8f2c6ec303d9e1443008c8e7f98e796159924b5fcb69235708b129fef0e46db98b5ecb60575ce40ff4493396499e625b0594996e67e76e745c20b224a87beda
   languageName: node
   linkType: hard
 
-"@monodeploy/git@npm:^3.9.0":
-  version: 3.9.0
-  resolution: "@monodeploy/git@npm:3.9.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40monodeploy%2Fgit%2F-%2Fgit-3.9.0.tgz"
+"@monodeploy/git@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@monodeploy/git@npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40monodeploy%2Fgit%2F-%2Fgit-4.0.1.tgz"
   dependencies:
     micromatch: ^4.0.5
   peerDependencies:
-    "@monodeploy/io": ^3.9.0
-    "@monodeploy/logging": ^3.8.0
-    "@monodeploy/types": ^3.9.0
-    "@yarnpkg/core": ^3.5.0
-    "@yarnpkg/fslib": ^2.10.2
-  checksum: 93e4ab84b428eff0ef74fffcf77e8e148ae2df753c10628586570fba788cc277f692748e505fccccec8e4da45eb5daee8af38b8f720fb65c2b1e714b07329b08
+    "@monodeploy/io": ^4.0.1
+    "@monodeploy/logging": ^4.0.1
+    "@monodeploy/types": ^4.0.1
+    "@yarnpkg/core": ^3.5.1
+    "@yarnpkg/fslib": ^2.10.3
+  checksum: d0632b6ae39b632b1653888d529a3251a39bcfe46553d216a7a53ec55e2bfefe8351e79bb9c70058402e9c49262341917e630baadf90777b36a0a4cc88e7a17d
   languageName: node
   linkType: hard
 
-"@monodeploy/io@npm:^3.9.0":
-  version: 3.9.0
-  resolution: "@monodeploy/io@npm:3.9.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40monodeploy%2Fio%2F-%2Fio-3.9.0.tgz"
+"@monodeploy/io@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@monodeploy/io@npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40monodeploy%2Fio%2F-%2Fio-4.0.1.tgz"
   dependencies:
-    semver: ^7.3.8
+    semver: ^7.4.0
   peerDependencies:
-    "@monodeploy/logging": ^3.8.0
-    "@monodeploy/types": ^3.9.0
-    "@yarnpkg/core": ^3.5.0
-    "@yarnpkg/fslib": ^2.10.2
+    "@monodeploy/logging": ^4.0.1
+    "@monodeploy/types": ^4.0.1
+    "@yarnpkg/core": ^3.5.1
+    "@yarnpkg/fslib": ^2.10.3
     "@yarnpkg/shell": ^3.2.5
-  checksum: aa5e489b193de24d40b254564a17c7cdb3b42ac28140705dc1f7d31dd11f42c9c3941add884221aed729771d5b1a54fd82df58d83f5601e6499d15428de6fd7b
+  checksum: 953c289e214aba3e6b4105134b185809e7f23430384ba06159398a86911418c8aaa9ce557eb7101e88a5f2efd91b7b141c6239fc91e98468e7044a3d2f843c5f
   languageName: node
   linkType: hard
 
-"@monodeploy/logging@npm:^3.8.0":
-  version: 3.8.0
-  resolution: "@monodeploy/logging@npm:3.8.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40monodeploy%2Flogging%2F-%2Flogging-3.8.0.tgz"
+"@monodeploy/logging@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@monodeploy/logging@npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40monodeploy%2Flogging%2F-%2Flogging-4.0.1.tgz"
   peerDependencies:
-    "@yarnpkg/core": ^3.5.0
-  checksum: b95121bf9d59391f136a7998a78029b146ce6515170f7c9f498e47294896ce169bdd09ba6b6bf8d67982290ddf51dca52a8c800b65fdfc13ed07f735726dfc35
+    "@yarnpkg/core": ^3.5.1
+  checksum: bdc4d8ff9f621357ee45aa26f8eb521fa8c45bfeb5ec74be5de6fff5315f97a4803677d129d582cdfe1a6e0c685f4b3541a56188d8bc2636dbca6ebad07e0c17
   languageName: node
   linkType: hard
 
-"@monodeploy/node@npm:^3.6.0":
-  version: 3.9.0
-  resolution: "@monodeploy/node@npm:3.9.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40monodeploy%2Fnode%2F-%2Fnode-3.9.0.tgz"
+"@monodeploy/node@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@monodeploy/node@npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40monodeploy%2Fnode%2F-%2Fnode-4.0.1.tgz"
   dependencies:
-    "@monodeploy/changelog": ^3.9.0
-    "@monodeploy/dependencies": ^3.9.0
-    "@monodeploy/git": ^3.9.0
-    "@monodeploy/io": ^3.9.0
-    "@monodeploy/logging": ^3.8.0
-    "@monodeploy/publish": ^3.9.0
-    "@monodeploy/types": ^3.9.0
-    "@monodeploy/versions": ^3.9.0
-    "@yarnpkg/cli": ^3.5.0
-    "@yarnpkg/core": ^3.5.0
-    "@yarnpkg/fslib": ^2.10.2
+    "@monodeploy/changelog": ^4.0.1
+    "@monodeploy/dependencies": ^4.0.1
+    "@monodeploy/git": ^4.0.1
+    "@monodeploy/io": ^4.0.1
+    "@monodeploy/logging": ^4.0.1
+    "@monodeploy/publish": ^4.0.1
+    "@monodeploy/types": ^4.0.1
+    "@monodeploy/versions": ^4.0.1
+    "@yarnpkg/cli": ^3.5.1
+    "@yarnpkg/core": ^3.5.1
+    "@yarnpkg/fslib": ^2.10.3
     "@yarnpkg/plugin-npm": ^2.7.3
     "@yarnpkg/plugin-pack": ^3.2.0
     "@yarnpkg/shell": ^3.2.5
     tapable: ^2.2.1
-  checksum: c26f6f6a2a4c8372271d64dfbdee254cf51778155b9c6b38b7f00ef5f03eedd19c4a76ef4926dec0fd2a975df3d1fc6fc3c104b1200daf27e7db9e94fa30f59b
+  checksum: b149e7e3de9233f86e5fd68be6038f69ee5e2191d262fb0155e0be53ccc4cf2f0ed175db5e57561c8d01943fa921b1bbd819d904f1de5742937b4ccb5cb82e14
   languageName: node
   linkType: hard
 
-"@monodeploy/publish@npm:^3.9.0":
-  version: 3.9.0
-  resolution: "@monodeploy/publish@npm:3.9.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40monodeploy%2Fpublish%2F-%2Fpublish-3.9.0.tgz"
+"@monodeploy/publish@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@monodeploy/publish@npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40monodeploy%2Fpublish%2F-%2Fpublish-4.0.1.tgz"
   dependencies:
     p-limit: ^3.1.0
   peerDependencies:
-    "@monodeploy/dependencies": ^3.9.0
-    "@monodeploy/git": ^3.9.0
-    "@monodeploy/io": ^3.9.0
-    "@monodeploy/logging": ^3.8.0
-    "@monodeploy/types": ^3.9.0
-    "@yarnpkg/cli": ^3.5.0
-    "@yarnpkg/core": ^3.5.0
-    "@yarnpkg/fslib": ^2.10.2
+    "@monodeploy/dependencies": ^4.0.1
+    "@monodeploy/git": ^4.0.1
+    "@monodeploy/io": ^4.0.1
+    "@monodeploy/logging": ^4.0.1
+    "@monodeploy/types": ^4.0.1
+    "@yarnpkg/cli": ^3.5.1
+    "@yarnpkg/core": ^3.5.1
+    "@yarnpkg/fslib": ^2.10.3
     "@yarnpkg/plugin-npm": ^2.7.3
     "@yarnpkg/plugin-pack": ^3.2.0
-  checksum: f6e37723573db3bee5391af5e6abde48d4347d050c4cb0560901e1dc812dedf85317f4738ce5f14398e6f0a7594f840e91fb0dfefc441d39eafbd3b66359b9f3
+  checksum: 7b4700537852becd52993bd621a5987f37cd1bde80c4b0b46c7d0ef534406c89d1da202f95c221cc2f4722b4bd4f0645affe94b41bc6d78743f447e47492a51b
   languageName: node
   linkType: hard
 
-"@monodeploy/types@npm:^3.6.0, @monodeploy/types@npm:^3.9.0":
-  version: 3.9.0
-  resolution: "@monodeploy/types@npm:3.9.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40monodeploy%2Ftypes%2F-%2Ftypes-3.9.0.tgz"
+"@monodeploy/types@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@monodeploy/types@npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40monodeploy%2Ftypes%2F-%2Ftypes-4.0.1.tgz"
   dependencies:
     tapable: ^2.2.1
   peerDependencies:
-    "@yarnpkg/core": ^3.5.0
-  checksum: 156daebedc7e3b35e216ef33daceed58d2b1bdfc64865c7daf2676845535b8d962b6401a65a727aab816f76fa60144d39fc4e3212e8eb5a2b0577277aa2190f1
+    "@yarnpkg/core": ^3.5.1
+  checksum: a3c7600a831b14cff15bbbe1e9b79c15b3df3561c8a08c8650d347c33fa50df1810a6f464c2f2c84094b88004d0c8412d45ebba180d17d8324132d4fc45190a5
   languageName: node
   linkType: hard
 
-"@monodeploy/versions@npm:^3.9.0":
-  version: 3.9.0
-  resolution: "@monodeploy/versions@npm:3.9.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40monodeploy%2Fversions%2F-%2Fversions-3.9.0.tgz"
+"@monodeploy/versions@npm:^4.0.1":
+  version: 4.0.1
+  resolution: "@monodeploy/versions@npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40monodeploy%2Fversions%2F-%2Fversions-4.0.1.tgz"
   dependencies:
     conventional-commits-parser: ^3.2.4
     micromatch: ^4.0.5
     p-limit: ^3.1.0
-    semver: ^7.3.8
+    semver: ^7.4.0
   peerDependencies:
-    "@monodeploy/changelog": ^3.9.0
-    "@monodeploy/dependencies": ^3.9.0
-    "@monodeploy/git": ^3.9.0
-    "@monodeploy/io": ^3.9.0
-    "@monodeploy/logging": ^3.8.0
-    "@monodeploy/types": ^3.9.0
-    "@yarnpkg/cli": ^3.5.0
-    "@yarnpkg/core": ^3.5.0
-    "@yarnpkg/fslib": ^2.10.2
+    "@monodeploy/changelog": ^4.0.1
+    "@monodeploy/dependencies": ^4.0.1
+    "@monodeploy/git": ^4.0.1
+    "@monodeploy/io": ^4.0.1
+    "@monodeploy/logging": ^4.0.1
+    "@monodeploy/types": ^4.0.1
+    "@yarnpkg/cli": ^3.5.1
+    "@yarnpkg/core": ^3.5.1
+    "@yarnpkg/fslib": ^2.10.3
     "@yarnpkg/plugin-npm": ^2.7.3
     "@yarnpkg/plugin-pack": ^3.2.0
-  checksum: f8b014fcd7a5e8af98309d1f22f7151a58160e828875f8d4f1146867ec9f7e8c6914973e79390bc8e14c913ca5acb64c3cea4841e39daeff87472e3781753ed2
+  checksum: b00080f3491f212dbde9858ec16e651948941c8c84a0e9a3e537861817e3c1c822bc3b7844d2466201f7e9f2f67fd10acf056304df508872c0076cab65c65f49
   languageName: node
   linkType: hard
 
@@ -4500,12 +4535,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@propeldata/release@workspace:packages/core/release"
   dependencies:
-    "@monodeploy/node": ^3.6.0
-    "@monodeploy/types": ^3.6.0
+    "@monodeploy/node": ^4.0.1
+    "@monodeploy/types": ^4.0.1
     "@tsconfig/node18": 1.0.1
-    conventional-changelog-angular: ^5.0.13
     eslint: ^8.32.0
     typescript: ^4.9.4
+  peerDependencies:
+    conventional-changelog-angular: ^6.0.0
   bin:
     propel-release: ./bin/propel-release
   languageName: unknown
@@ -4561,6 +4597,7 @@ __metadata:
     babel-loader: ^8.3.0
     chartjs-adapter-date-fns: ^3.0.0
     commitizen: ^4.2.5
+    conventional-changelog-angular: ^6.0.0
     cz-conventional-changelog: ^3.3.0
     eslint: ^8.28.0
     eslint-config-prettier: ^8.5.0
@@ -7461,29 +7498,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/cli@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "@yarnpkg/cli@npm:3.5.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40yarnpkg%2Fcli%2F-%2Fcli-3.5.0.tgz"
+"@yarnpkg/cli@npm:^3.5.1":
+  version: 3.6.0
+  resolution: "@yarnpkg/cli@npm:3.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40yarnpkg%2Fcli%2F-%2Fcli-3.6.0.tgz"
   dependencies:
-    "@yarnpkg/core": ^3.5.0
-    "@yarnpkg/fslib": ^2.10.2
+    "@yarnpkg/core": ^3.5.2
+    "@yarnpkg/fslib": ^2.10.3
     "@yarnpkg/libzip": ^2.3.0
     "@yarnpkg/parsers": ^2.5.1
-    "@yarnpkg/plugin-compat": ^3.1.10
+    "@yarnpkg/plugin-compat": ^3.1.12
     "@yarnpkg/plugin-dlx": ^3.1.4
     "@yarnpkg/plugin-essentials": ^3.3.0
     "@yarnpkg/plugin-file": ^2.3.1
-    "@yarnpkg/plugin-git": ^2.6.5
+    "@yarnpkg/plugin-git": ^2.6.6
     "@yarnpkg/plugin-github": ^2.3.1
     "@yarnpkg/plugin-http": ^2.2.1
     "@yarnpkg/plugin-init": ^3.2.1
     "@yarnpkg/plugin-link": ^2.2.1
     "@yarnpkg/plugin-nm": ^3.1.5
-    "@yarnpkg/plugin-npm": ^2.7.3
-    "@yarnpkg/plugin-npm-cli": ^3.3.0
+    "@yarnpkg/plugin-npm": ^2.7.4
+    "@yarnpkg/plugin-npm-cli": ^3.4.0
     "@yarnpkg/plugin-pack": ^3.2.0
     "@yarnpkg/plugin-patch": ^3.2.4
-    "@yarnpkg/plugin-pnp": ^3.2.8
+    "@yarnpkg/plugin-pnp": ^3.2.10
     "@yarnpkg/plugin-pnpm": ^1.1.3
     "@yarnpkg/shell": ^3.2.5
     chalk: ^3.0.0
@@ -7494,12 +7531,12 @@ __metadata:
     typanion: ^3.3.0
     yup: ^0.32.9
   peerDependencies:
-    "@yarnpkg/core": ^3.5.0
-  checksum: 840fe59a36392cd3b09459aa8e0297e68d74b584fcbbdcd6b8770833aa45420314a14771c861825bffb354c2a2804808f0afb138c6358796129903a5645ffaa6
+    "@yarnpkg/core": ^3.5.2
+  checksum: 1ac45d97920a7c26b5a2afdb7c368d2e7de611aa1c7f5b5c25721fc40163543c935eedf0436aac532e519ac51a2c1fe6954222b6462c1f8f1365766671deedd9
   languageName: node
   linkType: hard
 
-"@yarnpkg/core@npm:^3.3.0, @yarnpkg/core@npm:^3.5.0":
+"@yarnpkg/core@npm:^3.3.0":
   version: 3.5.0
   resolution: "@yarnpkg/core@npm:3.5.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40yarnpkg%2Fcore%2F-%2Fcore-3.5.0.tgz"
   dependencies:
@@ -7539,6 +7576,46 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@yarnpkg/core@npm:^3.5.1, @yarnpkg/core@npm:^3.5.2":
+  version: 3.5.2
+  resolution: "@yarnpkg/core@npm:3.5.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40yarnpkg%2Fcore%2F-%2Fcore-3.5.2.tgz"
+  dependencies:
+    "@arcanis/slice-ansi": ^1.1.1
+    "@types/semver": ^7.1.0
+    "@types/treeify": ^1.0.0
+    "@yarnpkg/fslib": ^2.10.3
+    "@yarnpkg/json-proxy": ^2.1.1
+    "@yarnpkg/libzip": ^2.3.0
+    "@yarnpkg/parsers": ^2.5.1
+    "@yarnpkg/pnp": ^3.3.3
+    "@yarnpkg/shell": ^3.2.5
+    camelcase: ^5.3.1
+    chalk: ^3.0.0
+    ci-info: ^3.2.0
+    clipanion: 3.2.0-rc.4
+    cross-spawn: 7.0.3
+    diff: ^5.1.0
+    globby: ^11.0.1
+    got: ^11.7.0
+    json-file-plus: ^3.3.1
+    lodash: ^4.17.15
+    micromatch: ^4.0.2
+    mkdirp: ^0.5.1
+    p-limit: ^2.2.0
+    pluralize: ^7.0.0
+    pretty-bytes: ^5.1.0
+    semver: ^7.1.2
+    stream-to-promise: ^2.2.0
+    strip-ansi: ^6.0.0
+    tar: ^6.0.5
+    tinylogic: ^1.0.3
+    treeify: ^1.1.0
+    tslib: ^1.13.0
+    tunnel: ^0.0.6
+  checksum: 7635ea96c79195afc2146a1b8c5adfcb765a83bce2721bc0c88799a01e0e0b73243631f47b57df14667d7349aa0cf0a6b28b6ecfc9814ef329c7dd1f4c7f3826
+  languageName: node
+  linkType: hard
+
 "@yarnpkg/extensions@npm:^1.1.2":
   version: 1.1.2
   resolution: "@yarnpkg/extensions@npm:1.1.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40yarnpkg%2Fextensions%2F-%2Fextensions-1.1.2.tgz"
@@ -7555,6 +7632,16 @@ __metadata:
     "@yarnpkg/libzip": ^2.3.0
     tslib: ^1.13.0
   checksum: 2cde3543c8cf6b1ae00bbc4602cae8a6198d8f29176d8eb575ed7902531d2d67f3a63e4c7e04927b7ee68a42103fefe22d0bf8d176c3f2bcfa5f47ecbe13aa01
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/fslib@npm:^2.10.3":
+  version: 2.10.3
+  resolution: "@yarnpkg/fslib@npm:2.10.3::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40yarnpkg%2Ffslib%2F-%2Ffslib-2.10.3.tgz"
+  dependencies:
+    "@yarnpkg/libzip": ^2.3.0
+    tslib: ^1.13.0
+  checksum: 0ca693f61d47bcf165411a121ed9123f512b1b5bfa5e1c6c8f280b4ffdbea9bf2a6db418f99ecfc9624587fdc695b2b64eb0fe7b4028e44095914b25ca99655e
   languageName: node
   linkType: hard
 
@@ -7599,15 +7686,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-compat@npm:^3.1.10":
-  version: 3.1.10
-  resolution: "@yarnpkg/plugin-compat@npm:3.1.10::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40yarnpkg%2Fplugin-compat%2F-%2Fplugin-compat-3.1.10.tgz"
+"@yarnpkg/plugin-compat@npm:^3.1.12":
+  version: 3.1.12
+  resolution: "@yarnpkg/plugin-compat@npm:3.1.12::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40yarnpkg%2Fplugin-compat%2F-%2Fplugin-compat-3.1.12.tgz"
   dependencies:
     "@yarnpkg/extensions": ^1.1.2
   peerDependencies:
-    "@yarnpkg/core": ^3.5.0
+    "@yarnpkg/core": ^3.5.2
     "@yarnpkg/plugin-patch": ^3.2.4
-  checksum: d20cd1155b24a7deed8f8eb794677d5fbc371704b7d2ec402b6f247bdf87a0e357151008b1b0cd144120127e92f6ec97e3b76a6c18932ff256192f487242ac9a
+  checksum: b1a4edeaeff4c698b5b1d7f7837d6ab30ac45d95c97320fedde08b2c5b5bf111d7245518422515503afca213438bea4ca1d93a50948b1699824d4ef68e2449fb
   languageName: node
   linkType: hard
 
@@ -7661,20 +7748,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-git@npm:^2.6.5":
-  version: 2.6.5
-  resolution: "@yarnpkg/plugin-git@npm:2.6.5::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40yarnpkg%2Fplugin-git%2F-%2Fplugin-git-2.6.5.tgz"
+"@yarnpkg/plugin-git@npm:^2.6.6":
+  version: 2.6.6
+  resolution: "@yarnpkg/plugin-git@npm:2.6.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40yarnpkg%2Fplugin-git%2F-%2Fplugin-git-2.6.6.tgz"
   dependencies:
     "@types/semver": ^7.1.0
-    "@yarnpkg/fslib": ^2.10.2
+    "@yarnpkg/fslib": ^2.10.3
     clipanion: 3.2.0-rc.4
     git-url-parse: ^13.1.0
     lodash: ^4.17.15
     semver: ^7.1.2
     tslib: ^1.13.0
   peerDependencies:
-    "@yarnpkg/core": ^3.5.0
-  checksum: c25fd81baee59851843eaa1af21853b35e02410830b25072ded265d78a862b83cd3b6048c8c98be3725253bac0da2abcb507c5d349742b247d87b9a704344abf
+    "@yarnpkg/core": ^3.5.2
+  checksum: 1bb90f56a934bc6006a7d2063d60a868c88e7ff59697691fd2ca02b3ab4961dcd5b49999c7e55335c2602e7601dea5c38572a53e3ea5595d50546d1245d1c4ef
   languageName: node
   linkType: hard
 
@@ -7751,11 +7838,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-npm-cli@npm:^3.3.0":
-  version: 3.3.0
-  resolution: "@yarnpkg/plugin-npm-cli@npm:3.3.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40yarnpkg%2Fplugin-npm-cli%2F-%2Fplugin-npm-cli-3.3.0.tgz"
+"@yarnpkg/plugin-npm-cli@npm:^3.4.0":
+  version: 3.4.0
+  resolution: "@yarnpkg/plugin-npm-cli@npm:3.4.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40yarnpkg%2Fplugin-npm-cli%2F-%2Fplugin-npm-cli-3.4.0.tgz"
   dependencies:
-    "@yarnpkg/fslib": ^2.9.0
+    "@yarnpkg/fslib": ^2.10.3
     clipanion: 3.2.0-rc.4
     enquirer: ^2.3.6
     micromatch: ^4.0.2
@@ -7763,11 +7850,11 @@ __metadata:
     tslib: ^1.13.0
     typanion: ^3.3.0
   peerDependencies:
-    "@yarnpkg/cli": ^3.3.0
-    "@yarnpkg/core": ^3.3.0
-    "@yarnpkg/plugin-npm": ^2.7.3
-    "@yarnpkg/plugin-pack": ^3.1.4
-  checksum: 97ba497fcbf30eb646d10a4b04aac606524e6c2f65e8450e028773f1be27ebd5c4637824cbb0a4c42953e0f924b9f6514631119b54ac01dba5258a336e829b76
+    "@yarnpkg/cli": ^3.6.0
+    "@yarnpkg/core": ^3.5.2
+    "@yarnpkg/plugin-npm": ^2.7.4
+    "@yarnpkg/plugin-pack": ^3.2.0
+  checksum: 3b234c5661757d0e4b74778043e2a170af2e22e1fbb8d62608b61e1db2a11924318b273d8fc1e4dbf8c4a23d6e831862206349c73fc7fbe70fe37b65070b24b2
   languageName: node
   linkType: hard
 
@@ -7784,6 +7871,22 @@ __metadata:
     "@yarnpkg/core": ^3.3.0
     "@yarnpkg/plugin-pack": ^3.1.4
   checksum: b33b5a666e3c298536aa2d00c23479b135853ad5329a76a68b403ca1725c34d0b571a69b1199c567332cc0faeccdb5dec23e1a125ff5e2285d9682573705b8bd
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/plugin-npm@npm:^2.7.4":
+  version: 2.7.4
+  resolution: "@yarnpkg/plugin-npm@npm:2.7.4::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40yarnpkg%2Fplugin-npm%2F-%2Fplugin-npm-2.7.4.tgz"
+  dependencies:
+    "@yarnpkg/fslib": ^2.10.3
+    enquirer: ^2.3.6
+    semver: ^7.1.2
+    ssri: ^6.0.1
+    tslib: ^1.13.0
+  peerDependencies:
+    "@yarnpkg/core": ^3.5.2
+    "@yarnpkg/plugin-pack": ^3.2.0
+  checksum: 296969efab88ba3b9af182b6522179ae7bcfa7167e5f84ffe4aef65b5e6b98fef4389983b24dbc22837548e9d631b09049243a488fc7485ca0ea20ffb16b4913
   languageName: node
   linkType: hard
 
@@ -7818,7 +7921,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@yarnpkg/plugin-pnp@npm:^3.2.5, @yarnpkg/plugin-pnp@npm:^3.2.6, @yarnpkg/plugin-pnp@npm:^3.2.8":
+"@yarnpkg/plugin-pnp@npm:^3.2.10":
+  version: 3.2.10
+  resolution: "@yarnpkg/plugin-pnp@npm:3.2.10::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40yarnpkg%2Fplugin-pnp%2F-%2Fplugin-pnp-3.2.10.tgz"
+  dependencies:
+    "@types/semver": ^7.1.0
+    "@yarnpkg/fslib": ^2.10.3
+    "@yarnpkg/plugin-stage": ^3.1.3
+    "@yarnpkg/pnp": ^3.3.3
+    clipanion: 3.2.0-rc.4
+    micromatch: ^4.0.2
+    semver: ^7.1.2
+    tslib: ^1.13.0
+  peerDependencies:
+    "@yarnpkg/cli": ^3.6.0
+    "@yarnpkg/core": ^3.5.2
+  checksum: 35a1e1a3db400db991a4c48bf2a317834cdbe39e0c3154b4e641204e20f76ffecd2e04214b45be393a9cb556d4c40f1843201d45ef7482f094ad3a7b9a86c65c
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/plugin-pnp@npm:^3.2.5, @yarnpkg/plugin-pnp@npm:^3.2.6":
   version: 3.2.8
   resolution: "@yarnpkg/plugin-pnp@npm:3.2.8::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40yarnpkg%2Fplugin-pnp%2F-%2Fplugin-pnp-3.2.8.tgz"
   dependencies:
@@ -7875,6 +7997,16 @@ __metadata:
     "@types/node": ^13.7.0
     "@yarnpkg/fslib": ^2.10.2
   checksum: dbc575a4255e659c9494ef49d73881f985597b5f1164e446d5fa5e565a1320265edfb15dd8efb679981355eb966ea706df627bbe1b842502206744f82b5af6a9
+  languageName: node
+  linkType: hard
+
+"@yarnpkg/pnp@npm:^3.3.3":
+  version: 3.3.3
+  resolution: "@yarnpkg/pnp@npm:3.3.3::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40yarnpkg%2Fpnp%2F-%2Fpnp-3.3.3.tgz"
+  dependencies:
+    "@types/node": ^13.7.0
+    "@yarnpkg/fslib": ^2.10.3
+  checksum: e379df5f8a6e1781f5af6f502b7d549642c62bf3c00fd9e6956389b7f6ccf4ee731b89d5c9569ff64eba5bf0b8d9003b7ad261d07a0506f7cba0cc70fedc4f33
   languageName: node
   linkType: hard
 
@@ -10611,13 +10743,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"conventional-changelog-angular@npm:^5.0.13":
-  version: 5.0.13
-  resolution: "conventional-changelog-angular@npm:5.0.13::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fconventional-changelog-angular%2F-%2Fconventional-changelog-angular-5.0.13.tgz"
+"conventional-changelog-angular@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "conventional-changelog-angular@npm:6.0.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fconventional-changelog-angular%2F-%2Fconventional-changelog-angular-6.0.0.tgz"
   dependencies:
     compare-func: ^2.0.0
-    q: ^1.5.1
-  checksum: 6ed4972fce25a50f9f038c749cc9db501363131b0fb2efc1fccecba14e4b1c80651d0d758d4c350a609f32010c66fa343eefd49c02e79e911884be28f53f3f90
+  checksum: ddc59ead53a45b817d83208200967f5340866782b8362d5e2e34105fdfa3d3a31585ebbdec7750bdb9de53da869f847e8ca96634a9801f51e27ecf4e7ffe2bad
   languageName: node
   linkType: hard
 
@@ -12606,7 +12737,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-scope@npm:^7.1.1":
+"eslint-scope@npm:^7.1.1, eslint-scope@npm:^7.2.0":
   version: 7.2.0
   resolution: "eslint-scope@npm:7.2.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-scope%2F-%2Feslint-scope-7.2.0.tgz"
   dependencies:
@@ -12630,6 +12761,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-visitor-keys@npm:^3.4.1":
+  version: 3.4.1
+  resolution: "eslint-visitor-keys@npm:3.4.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-visitor-keys%2F-%2Feslint-visitor-keys-3.4.1.tgz"
+  checksum: f05121d868202736b97de7d750847a328fcfa8593b031c95ea89425333db59676ac087fa905eba438d0a3c5769632f828187e0c1a0d271832a2153c1d3661c2c
+  languageName: node
+  linkType: hard
+
 "eslint-webpack-plugin@npm:^3.1.1":
   version: 3.2.0
   resolution: "eslint-webpack-plugin@npm:3.2.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-webpack-plugin%2F-%2Feslint-webpack-plugin-3.2.0.tgz"
@@ -12646,7 +12784,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^8.28.0, eslint@npm:^8.3.0, eslint@npm:^8.32.0":
+"eslint@npm:^8.28.0, eslint@npm:^8.3.0":
   version: 8.38.0
   resolution: "eslint@npm:8.38.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Feslint%2F-%2Feslint-8.38.0.tgz"
   dependencies:
@@ -12696,6 +12834,55 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint@npm:^8.32.0":
+  version: 8.42.0
+  resolution: "eslint@npm:8.42.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Feslint%2F-%2Feslint-8.42.0.tgz"
+  dependencies:
+    "@eslint-community/eslint-utils": ^4.2.0
+    "@eslint-community/regexpp": ^4.4.0
+    "@eslint/eslintrc": ^2.0.3
+    "@eslint/js": 8.42.0
+    "@humanwhocodes/config-array": ^0.11.10
+    "@humanwhocodes/module-importer": ^1.0.1
+    "@nodelib/fs.walk": ^1.2.8
+    ajv: ^6.10.0
+    chalk: ^4.0.0
+    cross-spawn: ^7.0.2
+    debug: ^4.3.2
+    doctrine: ^3.0.0
+    escape-string-regexp: ^4.0.0
+    eslint-scope: ^7.2.0
+    eslint-visitor-keys: ^3.4.1
+    espree: ^9.5.2
+    esquery: ^1.4.2
+    esutils: ^2.0.2
+    fast-deep-equal: ^3.1.3
+    file-entry-cache: ^6.0.1
+    find-up: ^5.0.0
+    glob-parent: ^6.0.2
+    globals: ^13.19.0
+    graphemer: ^1.4.0
+    ignore: ^5.2.0
+    import-fresh: ^3.0.0
+    imurmurhash: ^0.1.4
+    is-glob: ^4.0.0
+    is-path-inside: ^3.0.3
+    js-yaml: ^4.1.0
+    json-stable-stringify-without-jsonify: ^1.0.1
+    levn: ^0.4.1
+    lodash.merge: ^4.6.2
+    minimatch: ^3.1.2
+    natural-compare: ^1.4.0
+    optionator: ^0.9.1
+    strip-ansi: ^6.0.1
+    strip-json-comments: ^3.1.0
+    text-table: ^0.2.0
+  bin:
+    eslint: bin/eslint.js
+  checksum: 07105397b5f2ff4064b983b8971e8c379ec04b1dfcc9d918976b3e00377189000161dac991d82ba14f8759e466091b8c71146f602930ca810c290ee3fcb3faf0
+  languageName: node
+  linkType: hard
+
 "espree@npm:^9.5.1":
   version: 9.5.1
   resolution: "espree@npm:9.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fespree%2F-%2Fespree-9.5.1.tgz"
@@ -12704,6 +12891,17 @@ __metadata:
     acorn-jsx: ^5.3.2
     eslint-visitor-keys: ^3.4.0
   checksum: cdf6e43540433d917c4f2ee087c6e987b2063baa85a1d9cdaf51533d78275ebd5910c42154e7baf8e3e89804b386da0a2f7fad2264d8f04420e7506bf87b3b88
+  languageName: node
+  linkType: hard
+
+"espree@npm:^9.5.2":
+  version: 9.5.2
+  resolution: "espree@npm:9.5.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fespree%2F-%2Fespree-9.5.2.tgz"
+  dependencies:
+    acorn: ^8.8.0
+    acorn-jsx: ^5.3.2
+    eslint-visitor-keys: ^3.4.1
+  checksum: 6506289d6eb26471c0b383ee24fee5c8ae9d61ad540be956b3127be5ce3bf687d2ba6538ee5a86769812c7c552a9d8239e8c4d150f9ea056c6d5cbe8399c03c1
   languageName: node
   linkType: hard
 
@@ -14120,6 +14318,13 @@ __metadata:
   version: 1.0.4
   resolution: "grapheme-splitter@npm:1.0.4::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgrapheme-splitter%2F-%2Fgrapheme-splitter-1.0.4.tgz"
   checksum: 0c22ec54dee1b05cd480f78cf14f732cb5b108edc073572c4ec205df4cd63f30f8db8025afc5debc8835a8ddeacf648a1c7992fe3dcd6ad38f9a476d84906620
+  languageName: node
+  linkType: hard
+
+"graphemer@npm:^1.4.0":
+  version: 1.4.0
+  resolution: "graphemer@npm:1.4.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphemer%2F-%2Fgraphemer-1.4.0.tgz"
+  checksum: bab8f0be9b568857c7bec9fda95a89f87b783546d02951c40c33f84d05bb7da3fd10f863a9beb901463669b6583173a8c8cc6d6b306ea2b9b9d5d3d943c3a673
   languageName: node
   linkType: hard
 
@@ -21159,7 +21364,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"q@npm:^1.1.2, q@npm:^1.5.1":
+"q@npm:^1.1.2":
   version: 1.5.1
   resolution: "q@npm:1.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fq%2F-%2Fq-1.5.1.tgz"
   checksum: 147baa93c805bc1200ed698bdf9c72e9e42c05f96d007e33a558b5fdfd63e5ea130e99313f28efc1783e90e6bdb4e48b67a36fcc026b7b09202437ae88a1fb12
@@ -22710,6 +22915,17 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 2d266937756689a76f124ffb4c1ea3e1bbb2b263219f90ada8a11aebebe1280b13bb76cca2ca96bdee3dbc554cbc0b24752eb895b2a51577aa644427e9229f2b
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.4.0":
+  version: 7.5.1
+  resolution: "semver@npm:7.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fsemver%2F-%2Fsemver-7.5.1.tgz"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: d16dbedad53c65b086f79524b9ef766bf38670b2395bdad5c957f824dcc566b624988013564f4812bcace3f9d405355c3635e2007396a39d1bffc71cfec4a2fc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
With this change, the next version we will publish is 0.31.0. Merging this to main should create 0.31.0-rc.0.

@felipecadavid the actual release process will be slightly different than what we discussed yesterday, but I'll catch you up on it.

```
$ COMMIT_RELEASE=release DRY_RUN=true PRE_RELEASE=true yarn release
➤ YN0000: ┌ Determine New Versions
➤ YN0000: │ [Dry Run] [Version Change] @propeldata/ui-kit-components: 0.2.2 -> 0.31.0-rc.0 (minor, group: @propeldata/ui-kit)
➤ YN0000: │ [Dry Run] [Version Change] @propeldata/ui-kit-graphql: 0.2.8 -> 0.31.0-rc.0 (minor, group: @propeldata/ui-kit)
➤ YN0000: │ [Dry Run] [Version Change] @propeldata/ui-kit-plugins: 0.2.1 -> 0.31.0-rc.0 (minor, group: @propeldata/ui-kit)
➤ YN0000: │ [Dry Run] [Version Change] @propeldata/react-counter: 0.26.8 -> 0.31.0-rc.0 (minor, group: @propeldata/ui-kit)
➤ YN0000: │ [Dry Run] [Version Change] @propeldata/react-leaderboard: 0.5.4 -> 0.31.0-rc.0 (minor, group: @propeldata/ui-kit)
➤ YN0000: │ [Dry Run] [Version Change] @propeldata/react-time-series: 0.30.14 -> 0.31.0-rc.0 (minor, group: @propeldata/ui-kit)
➤ YN0000: └ Completed
➤ YN0000: ┌ Determine Git Tags
➤ YN0000: └ Completed
➤ YN0000: ┌ Generating Changeset
➤ YN0000: └ Completed
➤ YN0000: ┌ Fetching Workspace Information
➤ YN0000: └ Completed
➤ YN0000: ┌ Patching Package Manifests
➤ YN0000: └ Completed
➤ YN0000: ┌ Updating Project State
➤ YN0000: └ Completed
➤ YN0000: ┌ Updating Changelog
➤ YN0000: └ Completed
➤ YN0000: ┌ Committing Changes
➤ YN0000: │ [Dry Run] [Publish] Creating publish commit
➤ YN0000: └ Completed
➤ YN0000: ┌ Publishing Packages
➤ YN0000: │ [Dry Run] [Publish] @propeldata/ui-kit-components (next: 0.31.0-rc.0, https://registry.npmjs.com; undefined)
➤ YN0000: │ [Dry Run] [Publish] @propeldata/ui-kit-graphql (next: 0.31.0-rc.0, https://registry.npmjs.com; undefined)
➤ YN0000: │ [Dry Run] [Publish] @propeldata/ui-kit-plugins (next: 0.31.0-rc.0, https://registry.npmjs.com; undefined)
➤ YN0000: │ [Dry Run] [Publish] '@propeldata/ui-kit-components' published.
➤ YN0000: │ [Dry Run] [Publish] '@propeldata/ui-kit-plugins' published.
➤ YN0000: │ [Dry Run] [Publish] '@propeldata/ui-kit-graphql' published.
➤ YN0000: │ [Dry Run] [Publish] @propeldata/react-counter (next: 0.31.0-rc.0, https://registry.npmjs.com; undefined)
➤ YN0000: │ [Dry Run] [Publish] @propeldata/react-leaderboard (next: 0.31.0-rc.0, https://registry.npmjs.com; undefined)
➤ YN0000: │ [Dry Run] [Publish] @propeldata/react-time-series (next: 0.31.0-rc.0, https://registry.npmjs.com; undefined)
➤ YN0000: │ [Dry Run] [Publish] '@propeldata/react-counter' published.
➤ YN0000: │ [Dry Run] [Publish] '@propeldata/react-time-series' published.
➤ YN0000: │ [Dry Run] [Publish] '@propeldata/react-leaderboard' published.
➤ YN0000: └ Completed
➤ YN0000: [Dry Run] Monodeploy completed successfully
➤ YN0000: ┌ Cleaning Up
➤ YN0000: └ Completed
➤ YN0000: Done in 1s 668ms
[Dry Run] git push origin pre-release-support
[Dry Run] git push origin refs/tags/@propeldata/ui-kit@0.31.0-rc.0
```