### PR TITLE
feat: export types

### DIFF
--- a/packages/core/graphql/src/index.ts
+++ b/packages/core/graphql/src/index.ts
@@ -1,16 +1,4 @@
-export {
-  RelativeTimeRange,
-  TimeSeriesGranularity,
-  TimeSeriesDocument,
-  CounterDocument,
-  LeaderboardDocument,
-  Sort
-} from './generated'
-export type { TimeRangeInput, FilterInput, Propeller, LeaderboardInput } from './generated'
-
-export type { CounterQuery, CounterQueryVariables } from './generated'
-export type { TimeSeriesQuery, TimeSeriesQueryVariables } from './generated'
-export type { LeaderboardQuery, LeaderboardQueryVariables } from './generated'
+export * from './generated'
 
 // export const PROPEL_GRAPHQL_API_ENDPOINT = process.env.PROPEL_GRAPHQL_API_ENDPOINT as string
 export const PROPEL_GRAPHQL_API_ENDPOINT = 'https://api.us-east-2.propeldata.com/graphql'

--- a/packages/react/counter/src/Counter.tsx
+++ b/packages/react/counter/src/Counter.tsx
@@ -1,9 +1,10 @@
-import { CounterQuery, CounterQueryVariables } from '@propeldata/ui-kit-graphql/dist'
 import React from 'react'
 import request from 'graphql-request'
 import {
   PROPEL_GRAPHQL_API_ENDPOINT,
   CounterDocument,
+  CounterQuery,
+  CounterQueryVariables,
   TimeRangeInput,
   FilterInput,
   Propeller

--- a/packages/react/counter/src/index.ts
+++ b/packages/react/counter/src/index.ts
@@ -1,2 +1,11 @@
 export { Container as Counter } from './Container'
-export { RelativeTimeRange } from '@propeldata/ui-kit-graphql'
+
+export {
+  type FilterInput,
+  FilterOperator,
+  type InputMaybe,
+  Propeller,
+  RelativeTimeRange,
+  type Scalars,
+  type TimeRangeInput
+} from '@propeldata/ui-kit-graphql'

--- a/packages/react/leaderboard/src/Leaderboard.tsx
+++ b/packages/react/leaderboard/src/Leaderboard.tsx
@@ -1,8 +1,9 @@
-import { LeaderboardQuery, LeaderboardQueryVariables } from '@propeldata/ui-kit-graphql/dist'
 import React from 'react'
 import request from 'graphql-request'
 import {
   LeaderboardDocument,
+  LeaderboardQuery,
+  LeaderboardQueryVariables,
   TimeRangeInput,
   FilterInput,
   Propeller,

--- a/packages/react/leaderboard/src/index.ts
+++ b/packages/react/leaderboard/src/index.ts
@@ -1,2 +1,13 @@
 export { Container as Leaderboard } from './Container'
-export { RelativeTimeRange } from '@propeldata/ui-kit-graphql'
+
+export {
+  type DimensionInput,
+  type FilterInput,
+  FilterOperator,
+  type InputMaybe,
+  Propeller,
+  RelativeTimeRange,
+  type Scalars,
+  Sort,
+  type TimeRangeInput
+} from '@propeldata/ui-kit-graphql'

--- a/packages/react/time-series/src/TimeSeries.tsx
+++ b/packages/react/time-series/src/TimeSeries.tsx
@@ -1,10 +1,11 @@
-import { TimeSeriesQuery, TimeSeriesQueryVariables } from '@propeldata/ui-kit-graphql/dist'
 import React from 'react'
 import request from 'graphql-request'
 import { css } from '@emotion/css'
 import {
   TimeSeriesGranularity,
   TimeSeriesDocument,
+  TimeSeriesQuery,
+  TimeSeriesQueryVariables,
   TimeRangeInput,
   FilterInput,
   PROPEL_GRAPHQL_API_ENDPOINT,

--- a/packages/react/time-series/src/index.ts
+++ b/packages/react/time-series/src/index.ts
@@ -8,7 +8,6 @@ export {
   Propeller,
   RelativeTimeRange,
   type Scalars,
-  Sort,
   type TimeRangeInput,
   TimeSeriesGranularity
 } from '@propeldata/ui-kit-graphql'

--- a/packages/react/time-series/src/index.ts
+++ b/packages/react/time-series/src/index.ts
@@ -1,3 +1,14 @@
 export { Container as TimeSeries } from './Container'
-export { RelativeTimeRange, TimeSeriesGranularity } from '@propeldata/ui-kit-graphql'
 export type { Styles, ChartVariant, TimeSeriesData } from './types'
+
+export {
+  type FilterInput,
+  FilterOperator,
+  type InputMaybe,
+  Propeller,
+  RelativeTimeRange,
+  type Scalars,
+  Sort,
+  type TimeRangeInput,
+  TimeSeriesGranularity
+} from '@propeldata/ui-kit-graphql'


### PR DESCRIPTION
## Description of changes

This PR exports the various enums available when querying our GraphQL API. We do this, because customers want to use these constants in their apps. See https://linear.app/propel/issue/PRO-2126

Specifically,

| Enum | Relevant to… |
|:--- |:--- |
| FilterOperator | Counter, TimeSeries, Leaderboard |
| Propeller | Counter, TimeSeries, Leaderboard |
| RelativeTimeRange | Counter, TimeSeries, Leaderboard |
| Sort | Leaderboard |
| TimeSeriesGranularity | TimeSeries |

We also export some types as (like FilterInput, TimeRangeInput, etc.) as well.

## Checklist

Before merging to main:

- [ ] Tests
- [x] Manually tested in React apps
- [x] Release notes
- [ ] Approved

## Release notes

```md
# Component changes

## Time Series

- We now export the enums FilterOperator, Propeller, RelativeTimeRange, and TimeSeriesGranularity.
- We also export some other Time Series-specific GraphQL types.

## Leaderboard

- We now export the enums FilterOperator, Propeller, RelativeTimeRange, and Sort.
- We also export some other Leaderboard-specific GraphQL types.

## Counter

- We now export the enums FilterOperator, Propeller, and RelativeTimeRange.
- We also export some other Counter-specific GraphQL types.

```
