### PR TITLE
refactor: try using generated react-query hooks

### DIFF
--- a/.github/actions/prepare/action.yml
+++ b/.github/actions/prepare/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: 'Setup Node'
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '18'
     - name: 'Cache node_modules'
       uses: actions/cache@v3
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ build-storybook.log
 !.yarn/releases
 !.yarn/sdks
 !.yarn/versions
+
+mockHandlers.ts

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -6735,7 +6735,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["debug", "virtual:4bc25e11f539838b3b211f11c7fd4f02d2f615caca5670bfba690daf78dcd0e2083aa9b29f16bd338c39f20dbc414fa8ebdf706e864f914d72a1957e34186974#npm:4.3.4::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-4.3.4.tgz"],\
             ["dotenv", "npm:16.1.4::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fdotenv%2F-%2Fdotenv-16.1.4.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
+            ["graphql-request", "virtual:34c97827fbbc7c40b9b241f420cdf2f10a59971421ac74096a0636a57a50e03cb77d9d7cc6ff7b1eb458279d4544b661baa98bc7efca5e3b700c67f32273b773#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["http-proxy-agent", "npm:7.0.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fhttp-proxy-agent%2F-%2Fhttp-proxy-agent-7.0.0.tgz"],\
             ["https-proxy-agent", "npm:7.0.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fhttps-proxy-agent%2F-%2Fhttps-proxy-agent-7.0.0.tgz"],\
             ["jose", "npm:4.14.4::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjose%2F-%2Fjose-4.14.4.tgz"],\
@@ -8241,7 +8241,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/react-dom", "npm:18.2.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Freact-dom%2F-%2Freact-dom-18.2.6.tgz"],\
             ["@types/testing-library__jest-dom", "npm:5.14.7::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Ftesting-library__jest-dom%2F-%2Ftesting-library__jest-dom-5.14.7.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["jest", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest%2F-%2Fjest-27.5.1.tgz"],\
             ["jest-environment-jsdom", "npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-environment-jsdom%2F-%2Fjest-environment-jsdom-27.5.1.tgz"],\
             ["msw", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:1.2.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fmsw%2F-%2Fmsw-1.2.2.tgz"],\
@@ -8273,7 +8272,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/react-dom", "npm:18.2.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Freact-dom%2F-%2Freact-dom-18.2.6.tgz"],\
             ["@types/testing-library__jest-dom", "npm:5.14.7::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Ftesting-library__jest-dom%2F-%2Ftesting-library__jest-dom-5.14.7.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["jest", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest%2F-%2Fjest-27.5.1.tgz"],\
             ["jest-environment-jsdom", "npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-environment-jsdom%2F-%2Fjest-environment-jsdom-27.5.1.tgz"],\
             ["msw", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:1.2.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fmsw%2F-%2Fmsw-1.2.2.tgz"],\
@@ -8305,7 +8303,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/react-dom", "npm:18.2.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Freact-dom%2F-%2Freact-dom-18.2.6.tgz"],\
             ["@types/testing-library__jest-dom", "npm:5.14.7::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Ftesting-library__jest-dom%2F-%2Ftesting-library__jest-dom-5.14.7.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["jest", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest%2F-%2Fjest-27.5.1.tgz"],\
             ["jest-environment-jsdom", "npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-environment-jsdom%2F-%2Fjest-environment-jsdom-27.5.1.tgz"],\
             ["msw", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:1.2.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fmsw%2F-%2Fmsw-1.2.2.tgz"],\
@@ -8337,7 +8334,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/react-dom", "npm:18.2.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Freact-dom%2F-%2Freact-dom-18.2.6.tgz"],\
             ["@types/testing-library__jest-dom", "npm:5.14.7::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Ftesting-library__jest-dom%2F-%2Ftesting-library__jest-dom-5.14.7.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["jest", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest%2F-%2Fjest-27.5.1.tgz"],\
             ["jest-environment-jsdom", "npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-environment-jsdom%2F-%2Fjest-environment-jsdom-27.5.1.tgz"],\
             ["msw", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:1.2.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fmsw%2F-%2Fmsw-1.2.2.tgz"],\
@@ -8369,7 +8365,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/testing-library__jest-dom", "npm:5.14.7::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Ftesting-library__jest-dom%2F-%2Ftesting-library__jest-dom-5.14.7.tgz"],\
             ["chart.js", "npm:4.3.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fchart.js%2F-%2Fchart.js-4.3.0.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["jest", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest%2F-%2Fjest-27.5.1.tgz"],\
             ["jest-canvas-mock", "npm:2.5.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-canvas-mock%2F-%2Fjest-canvas-mock-2.5.2.tgz"],\
             ["jest-environment-jsdom", "npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-environment-jsdom%2F-%2Fjest-environment-jsdom-27.5.1.tgz"],\
@@ -8404,7 +8399,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/testing-library__jest-dom", "npm:5.14.7::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Ftesting-library__jest-dom%2F-%2Ftesting-library__jest-dom-5.14.7.tgz"],\
             ["chart.js", "npm:4.3.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fchart.js%2F-%2Fchart.js-4.3.0.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["jest", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest%2F-%2Fjest-27.5.1.tgz"],\
             ["jest-canvas-mock", "npm:2.5.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-canvas-mock%2F-%2Fjest-canvas-mock-2.5.2.tgz"],\
             ["jest-environment-jsdom", "npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-environment-jsdom%2F-%2Fjest-environment-jsdom-27.5.1.tgz"],\
@@ -8439,7 +8433,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/testing-library__jest-dom", "npm:5.14.7::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Ftesting-library__jest-dom%2F-%2Ftesting-library__jest-dom-5.14.7.tgz"],\
             ["chart.js", "npm:4.3.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fchart.js%2F-%2Fchart.js-4.3.0.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["jest", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest%2F-%2Fjest-27.5.1.tgz"],\
             ["jest-canvas-mock", "npm:2.5.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-canvas-mock%2F-%2Fjest-canvas-mock-2.5.2.tgz"],\
             ["jest-environment-jsdom", "npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-environment-jsdom%2F-%2Fjest-environment-jsdom-27.5.1.tgz"],\
@@ -8474,7 +8467,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/testing-library__jest-dom", "npm:5.14.7::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Ftesting-library__jest-dom%2F-%2Ftesting-library__jest-dom-5.14.7.tgz"],\
             ["chart.js", "npm:4.3.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fchart.js%2F-%2Fchart.js-4.3.0.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["jest", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest%2F-%2Fjest-27.5.1.tgz"],\
             ["jest-canvas-mock", "npm:2.5.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-canvas-mock%2F-%2Fjest-canvas-mock-2.5.2.tgz"],\
             ["jest-environment-jsdom", "npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-environment-jsdom%2F-%2Fjest-environment-jsdom-27.5.1.tgz"],\
@@ -8508,7 +8500,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["chart.js", "npm:4.3.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fchart.js%2F-%2Fchart.js-4.3.0.tgz"],\
             ["date-fns", "npm:2.30.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fdate-fns%2F-%2Fdate-fns-2.30.0.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["jest", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest%2F-%2Fjest-27.5.1.tgz"],\
             ["jest-canvas-mock", "npm:2.5.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-canvas-mock%2F-%2Fjest-canvas-mock-2.5.2.tgz"],\
             ["jest-environment-jsdom", "npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-environment-jsdom%2F-%2Fjest-environment-jsdom-27.5.1.tgz"],\
@@ -8544,7 +8535,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["chart.js", "npm:4.3.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fchart.js%2F-%2Fchart.js-4.3.0.tgz"],\
             ["date-fns", "npm:2.30.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fdate-fns%2F-%2Fdate-fns-2.30.0.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["jest", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest%2F-%2Fjest-27.5.1.tgz"],\
             ["jest-canvas-mock", "npm:2.5.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-canvas-mock%2F-%2Fjest-canvas-mock-2.5.2.tgz"],\
             ["jest-environment-jsdom", "npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-environment-jsdom%2F-%2Fjest-environment-jsdom-27.5.1.tgz"],\
@@ -8580,7 +8570,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["chart.js", "npm:4.3.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fchart.js%2F-%2Fchart.js-4.3.0.tgz"],\
             ["date-fns", "npm:2.30.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fdate-fns%2F-%2Fdate-fns-2.30.0.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["jest", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest%2F-%2Fjest-27.5.1.tgz"],\
             ["jest-canvas-mock", "npm:2.5.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-canvas-mock%2F-%2Fjest-canvas-mock-2.5.2.tgz"],\
             ["jest-environment-jsdom", "npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-environment-jsdom%2F-%2Fjest-environment-jsdom-27.5.1.tgz"],\
@@ -8616,7 +8605,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["chart.js", "npm:4.3.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fchart.js%2F-%2Fchart.js-4.3.0.tgz"],\
             ["date-fns", "npm:2.30.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fdate-fns%2F-%2Fdate-fns-2.30.0.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["jest", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest%2F-%2Fjest-27.5.1.tgz"],\
             ["jest-canvas-mock", "npm:2.5.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-canvas-mock%2F-%2Fjest-canvas-mock-2.5.2.tgz"],\
             ["jest-environment-jsdom", "npm:27.5.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fjest-environment-jsdom%2F-%2Fjest-environment-jsdom-27.5.1.tgz"],\
@@ -8762,7 +8750,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/react-dom", null],\
             ["dotenv", "npm:16.1.4::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fdotenv%2F-%2Fdotenv-16.1.4.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["react", "npm:18.2.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Freact%2F-%2Freact-18.2.0.tgz"],\
             ["react-dom", "virtual:b6fae5393a385f4f1bbe5a18f6e1eb116e43df87482141188b0ea2783134c1c43b4542d4d2bc120bac7fb6e4d07c5a98dceeaef7ca716c462765afdea8bc7675#npm:18.2.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Freact-dom%2F-%2Freact-dom-18.2.0.tgz"],\
             ["typescript", "patch:typescript@npm%3A4.9.5%3A%3A__archiveUrl=https%253A%252F%252Fregistry.npmjs.org%252Ftypescript%252F-%252Ftypescript-4.9.5.tgz#~builtin<compat/typescript>::version=4.9.5&hash=289587"]\
@@ -8791,7 +8778,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/react-dom", "npm:18.2.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Freact-dom%2F-%2Freact-dom-18.2.6.tgz"],\
             ["dotenv", "npm:16.1.4::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fdotenv%2F-%2Fdotenv-16.1.4.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["react", "npm:18.2.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Freact%2F-%2Freact-18.2.0.tgz"],\
             ["react-dom", "virtual:012fba26d05fe2b7968c247fd00f6d703974ceee00be7c6b7c230279d63549afec265694d8efc2797d41b9ae2aaf9f228496e6085795912f7a247c1e609c63b1#npm:18.2.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Freact-dom%2F-%2Freact-dom-18.2.0.tgz"],\
             ["typescript", "patch:typescript@npm%3A4.9.5%3A%3A__archiveUrl=https%253A%252F%252Fregistry.npmjs.org%252Ftypescript%252F-%252Ftypescript-4.9.5.tgz#~builtin<compat/typescript>::version=4.9.5&hash=289587"]\
@@ -8821,7 +8807,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/react-dom", "npm:18.2.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Freact-dom%2F-%2Freact-dom-18.2.6.tgz"],\
             ["dotenv", "npm:16.1.4::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fdotenv%2F-%2Fdotenv-16.1.4.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["react", "npm:18.2.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Freact%2F-%2Freact-18.2.0.tgz"],\
             ["react-dom", "virtual:b6fae5393a385f4f1bbe5a18f6e1eb116e43df87482141188b0ea2783134c1c43b4542d4d2bc120bac7fb6e4d07c5a98dceeaef7ca716c462765afdea8bc7675#npm:18.2.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Freact-dom%2F-%2Freact-dom-18.2.0.tgz"],\
             ["typescript", "patch:typescript@npm%3A4.9.5%3A%3A__archiveUrl=https%253A%252F%252Fregistry.npmjs.org%252Ftypescript%252F-%252Ftypescript-4.9.5.tgz#~builtin<compat/typescript>::version=4.9.5&hash=289587"]\
@@ -8851,7 +8836,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/react-dom", "npm:18.2.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Freact-dom%2F-%2Freact-dom-18.2.6.tgz"],\
             ["dotenv", "npm:16.1.4::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fdotenv%2F-%2Fdotenv-16.1.4.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["react", "npm:16.14.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Freact%2F-%2Freact-16.14.0.tgz"],\
             ["react-dom", "virtual:ac97dc161a7119c9069046e42490ca00bf6883b0c120a420828f620346e5a616f38063c37c4d30577588c8b903e63efd6999cff91af9cad2663faf104588286f#npm:16.14.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Freact-dom%2F-%2Freact-dom-16.14.0.tgz"],\
             ["typescript", "patch:typescript@npm%3A4.9.5%3A%3A__archiveUrl=https%253A%252F%252Fregistry.npmjs.org%252Ftypescript%252F-%252Ftypescript-4.9.5.tgz#~builtin<compat/typescript>::version=4.9.5&hash=289587"]\
@@ -8881,7 +8865,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@types/react-dom", "npm:18.2.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Freact-dom%2F-%2Freact-dom-18.2.6.tgz"],\
             ["dotenv", "npm:16.1.4::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fdotenv%2F-%2Fdotenv-16.1.4.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["react", "npm:17.0.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Freact%2F-%2Freact-17.0.2.tgz"],\
             ["react-dom", "virtual:5a5654a74dd0c04c5098a6f512068feec2c8e29bf2d7f2f4f51fc2ab6bc3c25e312c721937dac9a06feea26b637c0eedc3cdde0a175e4193238da9736337ebd8#npm:17.0.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Freact-dom%2F-%2Freact-dom-17.0.2.tgz"],\
             ["typescript", "patch:typescript@npm%3A4.9.5%3A%3A__archiveUrl=https%253A%252F%252Fregistry.npmjs.org%252Ftypescript%252F-%252Ftypescript-4.9.5.tgz#~builtin<compat/typescript>::version=4.9.5&hash=289587"]\
@@ -8908,7 +8891,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@tanstack/react-query", "virtual:46fc6faaec58571090e30e34692911b4e1abbaa431b52c2cb730745fcbf355d9178ef591e75901d89ff98228b359a5757937de2d69117ec94b616b228e28a2be#npm:4.29.17::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40tanstack%2Freact-query%2F-%2Freact-query-4.29.17.tgz"],\
             ["dotenv", "npm:16.1.4::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fdotenv%2F-%2Fdotenv-16.1.4.tgz"],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["react", "npm:18.2.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Freact%2F-%2Freact-18.2.0.tgz"],\
             ["react-dom", "virtual:b6fae5393a385f4f1bbe5a18f6e1eb116e43df87482141188b0ea2783134c1c43b4542d4d2bc120bac7fb6e4d07c5a98dceeaef7ca716c462765afdea8bc7675#npm:18.2.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Freact-dom%2F-%2Freact-dom-18.2.0.tgz"],\
             ["typescript", "patch:typescript@npm%3A4.9.5%3A%3A__archiveUrl=https%253A%252F%252Fregistry.npmjs.org%252Ftypescript%252F-%252Ftypescript-4.9.5.tgz#~builtin<compat/typescript>::version=4.9.5&hash=289587"]\
@@ -22223,10 +22205,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "SOFT"\
         }],\
-        ["virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz", {\
-          "packageLocation": "./.yarn/__virtual__/graphql-request-virtual-3d95f314a5/0/cache/graphql-request-npm-6.1.0-995737da11-6d62630a01.zip/node_modules/graphql-request/",\
+        ["virtual:34c97827fbbc7c40b9b241f420cdf2f10a59971421ac74096a0636a57a50e03cb77d9d7cc6ff7b1eb458279d4544b661baa98bc7efca5e3b700c67f32273b773#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz", {\
+          "packageLocation": "./.yarn/__virtual__/graphql-request-virtual-29015e2351/0/cache/graphql-request-npm-6.1.0-995737da11-6d62630a01.zip/node_modules/graphql-request/",\
           "packageDependencies": [\
-            ["graphql-request", "virtual:c33ffabfd17f1555516a2c847eaad8f993355a51df8e83d06fc00c00bd28f184a9069483f0d5d549e90358163e8cd5b53692b818ca39d786c87962d0487e221a#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
+            ["graphql-request", "virtual:34c97827fbbc7c40b9b241f420cdf2f10a59971421ac74096a0636a57a50e03cb77d9d7cc6ff7b1eb458279d4544b661baa98bc7efca5e3b700c67f32273b773#npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"],\
             ["@graphql-typed-document-node/core", "virtual:e234f0834604d8b90b6291daa51181f71ac8e96270fd64310acc36508b498d17e2d93a0479600e7ad127b8a2bfc6426bb27ce95fd9ba89e49dc76e99d8689439#npm:3.2.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-typed-document-node%2Fcore%2F-%2Fcore-3.2.0.tgz"],\
             ["@types/graphql", null],\
             ["cross-fetch", "npm:3.1.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fcross-fetch%2F-%2Fcross-fetch-3.1.6.tgz"],\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -5990,6 +5990,25 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "SOFT"\
         }],\
+        ["virtual:240957567e68234ef8b1dfd6acd8e4d5c589753495e50578ffe3f0ed211a62b86bc8392969f8cdc643b99dc074b8ff82398fe59d61aceebb07dd91bf42290c66#npm:2.7.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fplugin-helpers%2F-%2Fplugin-helpers-2.7.2.tgz", {\
+          "packageLocation": "./.yarn/__virtual__/@graphql-codegen-plugin-helpers-virtual-697a7f5a64/0/cache/@graphql-codegen-plugin-helpers-npm-2.7.2-342c61250c-66e0d507ad.zip/node_modules/@graphql-codegen/plugin-helpers/",\
+          "packageDependencies": [\
+            ["@graphql-codegen/plugin-helpers", "virtual:240957567e68234ef8b1dfd6acd8e4d5c589753495e50578ffe3f0ed211a62b86bc8392969f8cdc643b99dc074b8ff82398fe59d61aceebb07dd91bf42290c66#npm:2.7.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fplugin-helpers%2F-%2Fplugin-helpers-2.7.2.tgz"],\
+            ["@graphql-tools/utils", "virtual:697a7f5a64c22364b80da0a6a3212d7f6cbaaf140677be1b88b2e2f3ab3daf8c465aecbb678a6ff89095ab1270261b543d15414bc5fd059952a2dc9b472cb262#npm:8.13.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Futils%2F-%2Futils-8.13.1.tgz"],\
+            ["@types/graphql", null],\
+            ["change-case-all", "npm:1.0.14::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fchange-case-all%2F-%2Fchange-case-all-1.0.14.tgz"],\
+            ["common-tags", "npm:1.8.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fcommon-tags%2F-%2Fcommon-tags-1.8.2.tgz"],\
+            ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
+            ["import-from", "npm:4.0.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fimport-from%2F-%2Fimport-from-4.0.0.tgz"],\
+            ["lodash", "npm:4.17.21::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Flodash%2F-%2Flodash-4.17.21.tgz"],\
+            ["tslib", "npm:2.4.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Ftslib%2F-%2Ftslib-2.4.1.tgz"]\
+          ],\
+          "packagePeers": [\
+            "@types/graphql",\
+            "graphql"\
+          ],\
+          "linkType": "HARD"\
+        }],\
         ["virtual:3b3527d0eb6a0f15816fc4563bee7b6ddaa2fd5ccce3a9dd0def66c719f7d985b710c82822dfb2c41e1db9b65fd5d03c2847d47281267f969d0e987ada4c3ca0#npm:4.2.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fplugin-helpers%2F-%2Fplugin-helpers-4.2.0.tgz", {\
           "packageLocation": "./.yarn/__virtual__/@graphql-codegen-plugin-helpers-virtual-1dac6a08e0/0/cache/@graphql-codegen-plugin-helpers-npm-4.2.0-73e52b78fd-5d26adc132.zip/node_modules/@graphql-codegen/plugin-helpers/",\
           "packageDependencies": [\
@@ -6021,25 +6040,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["import-from", "npm:4.0.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fimport-from%2F-%2Fimport-from-4.0.0.tgz"],\
             ["lodash", "npm:4.17.21::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Flodash%2F-%2Flodash-4.17.21.tgz"],\
             ["tslib", "npm:2.5.3::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Ftslib%2F-%2Ftslib-2.5.3.tgz"]\
-          ],\
-          "packagePeers": [\
-            "@types/graphql",\
-            "graphql"\
-          ],\
-          "linkType": "HARD"\
-        }],\
-        ["virtual:b7b387d3785279c4e66ca45ce9f5690c7d9582f80e94f8235a3aa7c7525fcbcd815bfbf7432af7bf765838cfc35f215d4fcca99ac7a9f9fa2a4c13e8866f4935#npm:2.7.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fplugin-helpers%2F-%2Fplugin-helpers-2.7.2.tgz", {\
-          "packageLocation": "./.yarn/__virtual__/@graphql-codegen-plugin-helpers-virtual-2f9056333e/0/cache/@graphql-codegen-plugin-helpers-npm-2.7.2-342c61250c-66e0d507ad.zip/node_modules/@graphql-codegen/plugin-helpers/",\
-          "packageDependencies": [\
-            ["@graphql-codegen/plugin-helpers", "virtual:b7b387d3785279c4e66ca45ce9f5690c7d9582f80e94f8235a3aa7c7525fcbcd815bfbf7432af7bf765838cfc35f215d4fcca99ac7a9f9fa2a4c13e8866f4935#npm:2.7.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fplugin-helpers%2F-%2Fplugin-helpers-2.7.2.tgz"],\
-            ["@graphql-tools/utils", "virtual:b7b387d3785279c4e66ca45ce9f5690c7d9582f80e94f8235a3aa7c7525fcbcd815bfbf7432af7bf765838cfc35f215d4fcca99ac7a9f9fa2a4c13e8866f4935#npm:8.13.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Futils%2F-%2Futils-8.13.1.tgz"],\
-            ["@types/graphql", null],\
-            ["change-case-all", "npm:1.0.14::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fchange-case-all%2F-%2Fchange-case-all-1.0.14.tgz"],\
-            ["common-tags", "npm:1.8.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fcommon-tags%2F-%2Fcommon-tags-1.8.2.tgz"],\
-            ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["import-from", "npm:4.0.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fimport-from%2F-%2Fimport-from-4.0.0.tgz"],\
-            ["lodash", "npm:4.17.21::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Flodash%2F-%2Flodash-4.17.21.tgz"],\
-            ["tslib", "npm:2.4.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Ftslib%2F-%2Ftslib-2.4.1.tgz"]\
           ],\
           "packagePeers": [\
             "@types/graphql",\
@@ -6119,6 +6119,33 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "linkType": "HARD"\
         }]\
       ]],\
+      ["@graphql-codegen/typescript-msw", [\
+        ["npm:1.1.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-msw%2F-%2Ftypescript-msw-1.1.6.tgz", {\
+          "packageLocation": "./.yarn/cache/@graphql-codegen-typescript-msw-npm-1.1.6-cf5bb0f04d-85f1b71c01.zip/node_modules/@graphql-codegen/typescript-msw/",\
+          "packageDependencies": [\
+            ["@graphql-codegen/typescript-msw", "npm:1.1.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-msw%2F-%2Ftypescript-msw-1.1.6.tgz"]\
+          ],\
+          "linkType": "SOFT"\
+        }],\
+        ["virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:1.1.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-msw%2F-%2Ftypescript-msw-1.1.6.tgz", {\
+          "packageLocation": "./.yarn/__virtual__/@graphql-codegen-typescript-msw-virtual-240957567e/0/cache/@graphql-codegen-typescript-msw-npm-1.1.6-cf5bb0f04d-85f1b71c01.zip/node_modules/@graphql-codegen/typescript-msw/",\
+          "packageDependencies": [\
+            ["@graphql-codegen/typescript-msw", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:1.1.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-msw%2F-%2Ftypescript-msw-1.1.6.tgz"],\
+            ["@graphql-codegen/plugin-helpers", "virtual:240957567e68234ef8b1dfd6acd8e4d5c589753495e50578ffe3f0ed211a62b86bc8392969f8cdc643b99dc074b8ff82398fe59d61aceebb07dd91bf42290c66#npm:2.7.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fplugin-helpers%2F-%2Fplugin-helpers-2.7.2.tgz"],\
+            ["@graphql-codegen/visitor-plugin-common", "virtual:240957567e68234ef8b1dfd6acd8e4d5c589753495e50578ffe3f0ed211a62b86bc8392969f8cdc643b99dc074b8ff82398fe59d61aceebb07dd91bf42290c66#npm:2.13.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fvisitor-plugin-common%2F-%2Fvisitor-plugin-common-2.13.1.tgz"],\
+            ["@types/graphql", null],\
+            ["auto-bind", "npm:4.0.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fauto-bind%2F-%2Fauto-bind-4.0.0.tgz"],\
+            ["change-case-all", "npm:1.0.14::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fchange-case-all%2F-%2Fchange-case-all-1.0.14.tgz"],\
+            ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
+            ["tslib", "npm:2.4.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Ftslib%2F-%2Ftslib-2.4.1.tgz"]\
+          ],\
+          "packagePeers": [\
+            "@types/graphql",\
+            "graphql"\
+          ],\
+          "linkType": "HARD"\
+        }]\
+      ]],\
       ["@graphql-codegen/typescript-operations", [\
         ["npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-operations%2F-%2Ftypescript-operations-4.0.1.tgz", {\
           "packageLocation": "./.yarn/cache/@graphql-codegen-typescript-operations-npm-4.0.1-2642b820ee-82cd58ceb7.zip/node_modules/@graphql-codegen/typescript-operations/",\
@@ -6159,7 +6186,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           "packageDependencies": [\
             ["@graphql-codegen/typescript-react-query", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-react-query%2F-%2Ftypescript-react-query-4.1.0.tgz"],\
             ["@graphql-codegen/plugin-helpers", "virtual:c2de77828b08c74515f3e3fa244279a392976e861ee0fb9f5096165042b55fe44c6f87bed3e343a1193fc613cc794e79d178045698c56d651e9a48b695f91621#npm:3.1.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fplugin-helpers%2F-%2Fplugin-helpers-3.1.2.tgz"],\
-            ["@graphql-codegen/visitor-plugin-common", "virtual:c2de77828b08c74515f3e3fa244279a392976e861ee0fb9f5096165042b55fe44c6f87bed3e343a1193fc613cc794e79d178045698c56d651e9a48b695f91621#npm:2.13.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fvisitor-plugin-common%2F-%2Fvisitor-plugin-common-2.13.1.tgz"],\
+            ["@graphql-codegen/visitor-plugin-common", "virtual:240957567e68234ef8b1dfd6acd8e4d5c589753495e50578ffe3f0ed211a62b86bc8392969f8cdc643b99dc074b8ff82398fe59d61aceebb07dd91bf42290c66#npm:2.13.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fvisitor-plugin-common%2F-%2Fvisitor-plugin-common-2.13.1.tgz"],\
             ["@types/graphql", null],\
             ["auto-bind", "npm:4.0.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fauto-bind%2F-%2Fauto-bind-4.0.0.tgz"],\
             ["change-case-all", "npm:1.0.15::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fchange-case-all%2F-%2Fchange-case-all-1.0.15.tgz"],\
@@ -6188,6 +6215,29 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "SOFT"\
         }],\
+        ["virtual:240957567e68234ef8b1dfd6acd8e4d5c589753495e50578ffe3f0ed211a62b86bc8392969f8cdc643b99dc074b8ff82398fe59d61aceebb07dd91bf42290c66#npm:2.13.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fvisitor-plugin-common%2F-%2Fvisitor-plugin-common-2.13.1.tgz", {\
+          "packageLocation": "./.yarn/__virtual__/@graphql-codegen-visitor-plugin-common-virtual-788a707775/0/cache/@graphql-codegen-visitor-plugin-common-npm-2.13.1-ae50da21ce-0c329aa6e4.zip/node_modules/@graphql-codegen/visitor-plugin-common/",\
+          "packageDependencies": [\
+            ["@graphql-codegen/visitor-plugin-common", "virtual:240957567e68234ef8b1dfd6acd8e4d5c589753495e50578ffe3f0ed211a62b86bc8392969f8cdc643b99dc074b8ff82398fe59d61aceebb07dd91bf42290c66#npm:2.13.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fvisitor-plugin-common%2F-%2Fvisitor-plugin-common-2.13.1.tgz"],\
+            ["@graphql-codegen/plugin-helpers", "virtual:240957567e68234ef8b1dfd6acd8e4d5c589753495e50578ffe3f0ed211a62b86bc8392969f8cdc643b99dc074b8ff82398fe59d61aceebb07dd91bf42290c66#npm:2.7.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fplugin-helpers%2F-%2Fplugin-helpers-2.7.2.tgz"],\
+            ["@graphql-tools/optimize", "virtual:788a707775b50aa0a8b81c9dae7f42fa0b0c2a893118e572dc06fad64812fd51fd3a9f372b0638d384b4ff0932097dfc7abbcf86e791024c8caac1f00594bf21#npm:1.4.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Foptimize%2F-%2Foptimize-1.4.0.tgz"],\
+            ["@graphql-tools/relay-operation-optimizer", "virtual:788a707775b50aa0a8b81c9dae7f42fa0b0c2a893118e572dc06fad64812fd51fd3a9f372b0638d384b4ff0932097dfc7abbcf86e791024c8caac1f00594bf21#npm:6.5.18::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Frelay-operation-optimizer%2F-%2Frelay-operation-optimizer-6.5.18.tgz"],\
+            ["@graphql-tools/utils", "virtual:697a7f5a64c22364b80da0a6a3212d7f6cbaaf140677be1b88b2e2f3ab3daf8c465aecbb678a6ff89095ab1270261b543d15414bc5fd059952a2dc9b472cb262#npm:8.13.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Futils%2F-%2Futils-8.13.1.tgz"],\
+            ["@types/graphql", null],\
+            ["auto-bind", "npm:4.0.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fauto-bind%2F-%2Fauto-bind-4.0.0.tgz"],\
+            ["change-case-all", "npm:1.0.14::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fchange-case-all%2F-%2Fchange-case-all-1.0.14.tgz"],\
+            ["dependency-graph", "npm:0.11.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fdependency-graph%2F-%2Fdependency-graph-0.11.0.tgz"],\
+            ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
+            ["graphql-tag", "virtual:f790553b58f0d3102d624831fbdc9c445d1992edd4c9a5c3c84a338b3cc173e2eaa211a00564d4862a523c5e2034d896baf9dff4bb7b717388a4273f3c6c7260#npm:2.12.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-tag%2F-%2Fgraphql-tag-2.12.6.tgz"],\
+            ["parse-filepath", "npm:1.0.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fparse-filepath%2F-%2Fparse-filepath-1.0.2.tgz"],\
+            ["tslib", "npm:2.4.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Ftslib%2F-%2Ftslib-2.4.1.tgz"]\
+          ],\
+          "packagePeers": [\
+            "@types/graphql",\
+            "graphql"\
+          ],\
+          "linkType": "HARD"\
+        }],\
         ["virtual:8dbacc262fbbde31ee706601ff275c50b5982c44d37f03bd4c1b9a9ce3370ffd0c08f6697351183b2a7ec114a5ee3e525051eeecd6857a4f8331815f71cc4c24#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fvisitor-plugin-common%2F-%2Fvisitor-plugin-common-4.0.1.tgz", {\
           "packageLocation": "./.yarn/__virtual__/@graphql-codegen-visitor-plugin-common-virtual-f790553b58/0/cache/@graphql-codegen-visitor-plugin-common-npm-4.0.1-517bbe2903-72fe72850b.zip/node_modules/@graphql-codegen/visitor-plugin-common/",\
           "packageDependencies": [\
@@ -6204,29 +6254,6 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["graphql-tag", "virtual:f790553b58f0d3102d624831fbdc9c445d1992edd4c9a5c3c84a338b3cc173e2eaa211a00564d4862a523c5e2034d896baf9dff4bb7b717388a4273f3c6c7260#npm:2.12.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-tag%2F-%2Fgraphql-tag-2.12.6.tgz"],\
             ["parse-filepath", "npm:1.0.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fparse-filepath%2F-%2Fparse-filepath-1.0.2.tgz"],\
             ["tslib", "npm:2.5.3::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Ftslib%2F-%2Ftslib-2.5.3.tgz"]\
-          ],\
-          "packagePeers": [\
-            "@types/graphql",\
-            "graphql"\
-          ],\
-          "linkType": "HARD"\
-        }],\
-        ["virtual:c2de77828b08c74515f3e3fa244279a392976e861ee0fb9f5096165042b55fe44c6f87bed3e343a1193fc613cc794e79d178045698c56d651e9a48b695f91621#npm:2.13.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fvisitor-plugin-common%2F-%2Fvisitor-plugin-common-2.13.1.tgz", {\
-          "packageLocation": "./.yarn/__virtual__/@graphql-codegen-visitor-plugin-common-virtual-b7b387d378/0/cache/@graphql-codegen-visitor-plugin-common-npm-2.13.1-ae50da21ce-0c329aa6e4.zip/node_modules/@graphql-codegen/visitor-plugin-common/",\
-          "packageDependencies": [\
-            ["@graphql-codegen/visitor-plugin-common", "virtual:c2de77828b08c74515f3e3fa244279a392976e861ee0fb9f5096165042b55fe44c6f87bed3e343a1193fc613cc794e79d178045698c56d651e9a48b695f91621#npm:2.13.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fvisitor-plugin-common%2F-%2Fvisitor-plugin-common-2.13.1.tgz"],\
-            ["@graphql-codegen/plugin-helpers", "virtual:b7b387d3785279c4e66ca45ce9f5690c7d9582f80e94f8235a3aa7c7525fcbcd815bfbf7432af7bf765838cfc35f215d4fcca99ac7a9f9fa2a4c13e8866f4935#npm:2.7.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fplugin-helpers%2F-%2Fplugin-helpers-2.7.2.tgz"],\
-            ["@graphql-tools/optimize", "virtual:b7b387d3785279c4e66ca45ce9f5690c7d9582f80e94f8235a3aa7c7525fcbcd815bfbf7432af7bf765838cfc35f215d4fcca99ac7a9f9fa2a4c13e8866f4935#npm:1.4.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Foptimize%2F-%2Foptimize-1.4.0.tgz"],\
-            ["@graphql-tools/relay-operation-optimizer", "virtual:b7b387d3785279c4e66ca45ce9f5690c7d9582f80e94f8235a3aa7c7525fcbcd815bfbf7432af7bf765838cfc35f215d4fcca99ac7a9f9fa2a4c13e8866f4935#npm:6.5.18::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Frelay-operation-optimizer%2F-%2Frelay-operation-optimizer-6.5.18.tgz"],\
-            ["@graphql-tools/utils", "virtual:b7b387d3785279c4e66ca45ce9f5690c7d9582f80e94f8235a3aa7c7525fcbcd815bfbf7432af7bf765838cfc35f215d4fcca99ac7a9f9fa2a4c13e8866f4935#npm:8.13.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Futils%2F-%2Futils-8.13.1.tgz"],\
-            ["@types/graphql", null],\
-            ["auto-bind", "npm:4.0.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fauto-bind%2F-%2Fauto-bind-4.0.0.tgz"],\
-            ["change-case-all", "npm:1.0.14::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fchange-case-all%2F-%2Fchange-case-all-1.0.14.tgz"],\
-            ["dependency-graph", "npm:0.11.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fdependency-graph%2F-%2Fdependency-graph-0.11.0.tgz"],\
-            ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
-            ["graphql-tag", "virtual:f790553b58f0d3102d624831fbdc9c445d1992edd4c9a5c3c84a338b3cc173e2eaa211a00564d4862a523c5e2034d896baf9dff4bb7b717388a4273f3c6c7260#npm:2.12.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-tag%2F-%2Fgraphql-tag-2.12.6.tgz"],\
-            ["parse-filepath", "npm:1.0.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fparse-filepath%2F-%2Fparse-filepath-1.0.2.tgz"],\
-            ["tslib", "npm:2.4.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Ftslib%2F-%2Ftslib-2.4.1.tgz"]\
           ],\
           "packagePeers": [\
             "@types/graphql",\
@@ -6684,10 +6711,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "SOFT"\
         }],\
-        ["virtual:b7b387d3785279c4e66ca45ce9f5690c7d9582f80e94f8235a3aa7c7525fcbcd815bfbf7432af7bf765838cfc35f215d4fcca99ac7a9f9fa2a4c13e8866f4935#npm:1.4.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Foptimize%2F-%2Foptimize-1.4.0.tgz", {\
-          "packageLocation": "./.yarn/__virtual__/@graphql-tools-optimize-virtual-76ea8ce0ea/0/cache/@graphql-tools-optimize-npm-1.4.0-a360eb67b9-bccbc596f2.zip/node_modules/@graphql-tools/optimize/",\
+        ["virtual:788a707775b50aa0a8b81c9dae7f42fa0b0c2a893118e572dc06fad64812fd51fd3a9f372b0638d384b4ff0932097dfc7abbcf86e791024c8caac1f00594bf21#npm:1.4.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Foptimize%2F-%2Foptimize-1.4.0.tgz", {\
+          "packageLocation": "./.yarn/__virtual__/@graphql-tools-optimize-virtual-0e95021942/0/cache/@graphql-tools-optimize-npm-1.4.0-a360eb67b9-bccbc596f2.zip/node_modules/@graphql-tools/optimize/",\
           "packageDependencies": [\
-            ["@graphql-tools/optimize", "virtual:b7b387d3785279c4e66ca45ce9f5690c7d9582f80e94f8235a3aa7c7525fcbcd815bfbf7432af7bf765838cfc35f215d4fcca99ac7a9f9fa2a4c13e8866f4935#npm:1.4.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Foptimize%2F-%2Foptimize-1.4.0.tgz"],\
+            ["@graphql-tools/optimize", "virtual:788a707775b50aa0a8b81c9dae7f42fa0b0c2a893118e572dc06fad64812fd51fd3a9f372b0638d384b4ff0932097dfc7abbcf86e791024c8caac1f00594bf21#npm:1.4.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Foptimize%2F-%2Foptimize-1.4.0.tgz"],\
             ["@types/graphql", null],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
             ["tslib", "npm:2.5.3::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Ftslib%2F-%2Ftslib-2.5.3.tgz"]\
@@ -6768,10 +6795,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "SOFT"\
         }],\
-        ["virtual:b7b387d3785279c4e66ca45ce9f5690c7d9582f80e94f8235a3aa7c7525fcbcd815bfbf7432af7bf765838cfc35f215d4fcca99ac7a9f9fa2a4c13e8866f4935#npm:6.5.18::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Frelay-operation-optimizer%2F-%2Frelay-operation-optimizer-6.5.18.tgz", {\
-          "packageLocation": "./.yarn/__virtual__/@graphql-tools-relay-operation-optimizer-virtual-3a1fb6ebd7/0/cache/@graphql-tools-relay-operation-optimizer-npm-6.5.18-ae324527a1-56a8c7e6a0.zip/node_modules/@graphql-tools/relay-operation-optimizer/",\
+        ["virtual:788a707775b50aa0a8b81c9dae7f42fa0b0c2a893118e572dc06fad64812fd51fd3a9f372b0638d384b4ff0932097dfc7abbcf86e791024c8caac1f00594bf21#npm:6.5.18::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Frelay-operation-optimizer%2F-%2Frelay-operation-optimizer-6.5.18.tgz", {\
+          "packageLocation": "./.yarn/__virtual__/@graphql-tools-relay-operation-optimizer-virtual-30093475c4/0/cache/@graphql-tools-relay-operation-optimizer-npm-6.5.18-ae324527a1-56a8c7e6a0.zip/node_modules/@graphql-tools/relay-operation-optimizer/",\
           "packageDependencies": [\
-            ["@graphql-tools/relay-operation-optimizer", "virtual:b7b387d3785279c4e66ca45ce9f5690c7d9582f80e94f8235a3aa7c7525fcbcd815bfbf7432af7bf765838cfc35f215d4fcca99ac7a9f9fa2a4c13e8866f4935#npm:6.5.18::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Frelay-operation-optimizer%2F-%2Frelay-operation-optimizer-6.5.18.tgz"],\
+            ["@graphql-tools/relay-operation-optimizer", "virtual:788a707775b50aa0a8b81c9dae7f42fa0b0c2a893118e572dc06fad64812fd51fd3a9f372b0638d384b4ff0932097dfc7abbcf86e791024c8caac1f00594bf21#npm:6.5.18::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Frelay-operation-optimizer%2F-%2Frelay-operation-optimizer-6.5.18.tgz"],\
             ["@ardatan/relay-compiler", "virtual:9fc4eb74354449db77a01a0a634cf2b066105a3398cac4078f0e5144e3dc07338dce4c30b8a773dc33c8874319596b3603971c71b28b8be3126d030563cf5fcb#npm:12.0.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40ardatan%2Frelay-compiler%2F-%2Frelay-compiler-12.0.0.tgz"],\
             ["@graphql-tools/utils", "virtual:1dac6a08e0407181a6b748b555541cb265480a94c47047221b001fa05bc40ee03a970c39629620a4963cceaca72575357d2ad06ffb986081fa0624d8849128b5#npm:9.2.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Futils%2F-%2Futils-9.2.1.tgz"],\
             ["@types/graphql", null],\
@@ -6914,10 +6941,10 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
           ],\
           "linkType": "HARD"\
         }],\
-        ["virtual:b7b387d3785279c4e66ca45ce9f5690c7d9582f80e94f8235a3aa7c7525fcbcd815bfbf7432af7bf765838cfc35f215d4fcca99ac7a9f9fa2a4c13e8866f4935#npm:8.13.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Futils%2F-%2Futils-8.13.1.tgz", {\
-          "packageLocation": "./.yarn/__virtual__/@graphql-tools-utils-virtual-20b3359b77/0/cache/@graphql-tools-utils-npm-8.13.1-7e285a7a13-ff04fdeb29.zip/node_modules/@graphql-tools/utils/",\
+        ["virtual:697a7f5a64c22364b80da0a6a3212d7f6cbaaf140677be1b88b2e2f3ab3daf8c465aecbb678a6ff89095ab1270261b543d15414bc5fd059952a2dc9b472cb262#npm:8.13.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Futils%2F-%2Futils-8.13.1.tgz", {\
+          "packageLocation": "./.yarn/__virtual__/@graphql-tools-utils-virtual-05a8284299/0/cache/@graphql-tools-utils-npm-8.13.1-7e285a7a13-ff04fdeb29.zip/node_modules/@graphql-tools/utils/",\
           "packageDependencies": [\
-            ["@graphql-tools/utils", "virtual:b7b387d3785279c4e66ca45ce9f5690c7d9582f80e94f8235a3aa7c7525fcbcd815bfbf7432af7bf765838cfc35f215d4fcca99ac7a9f9fa2a4c13e8866f4935#npm:8.13.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Futils%2F-%2Futils-8.13.1.tgz"],\
+            ["@graphql-tools/utils", "virtual:697a7f5a64c22364b80da0a6a3212d7f6cbaaf140677be1b88b2e2f3ab3daf8c465aecbb678a6ff89095ab1270261b543d15414bc5fd059952a2dc9b472cb262#npm:8.13.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-tools%2Futils%2F-%2Futils-8.13.1.tgz"],\
             ["@types/graphql", null],\
             ["graphql", "npm:16.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql%2F-%2Fgraphql-16.6.0.tgz"],\
             ["tslib", "npm:2.5.3::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Ftslib%2F-%2Ftslib-2.5.3.tgz"]\
@@ -8742,6 +8769,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@graphql-codegen/add", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fadd%2F-%2Fadd-4.0.1.tgz"],\
             ["@graphql-codegen/cli", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fcli%2F-%2Fcli-4.0.1.tgz"],\
             ["@graphql-codegen/typescript", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript%2F-%2Ftypescript-4.0.1.tgz"],\
+            ["@graphql-codegen/typescript-msw", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:1.1.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-msw%2F-%2Ftypescript-msw-1.1.6.tgz"],\
             ["@graphql-codegen/typescript-operations", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-operations%2F-%2Ftypescript-operations-4.0.1.tgz"],\
             ["@graphql-codegen/typescript-react-query", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-react-query%2F-%2Ftypescript-react-query-4.1.0.tgz"],\
             ["@tanstack/react-query", "virtual:46fc6faaec58571090e30e34692911b4e1abbaa431b52c2cb730745fcbf355d9178ef591e75901d89ff98228b359a5757937de2d69117ec94b616b228e28a2be#npm:4.29.17::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40tanstack%2Freact-query%2F-%2Freact-query-4.29.17.tgz"],\
@@ -8770,6 +8798,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@graphql-codegen/add", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fadd%2F-%2Fadd-4.0.1.tgz"],\
             ["@graphql-codegen/cli", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fcli%2F-%2Fcli-4.0.1.tgz"],\
             ["@graphql-codegen/typescript", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript%2F-%2Ftypescript-4.0.1.tgz"],\
+            ["@graphql-codegen/typescript-msw", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:1.1.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-msw%2F-%2Ftypescript-msw-1.1.6.tgz"],\
             ["@graphql-codegen/typescript-operations", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-operations%2F-%2Ftypescript-operations-4.0.1.tgz"],\
             ["@graphql-codegen/typescript-react-query", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-react-query%2F-%2Ftypescript-react-query-4.1.0.tgz"],\
             ["@tanstack/react-query", "virtual:816f6e982626ba1fb5fc011255e0fc21fbff8c43612ac6f6402d1c228804b40dfc4313f6f9d0690aa2cbf318c776f90bd59774dccdb23605211fc683422a3f5c#npm:4.29.17::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40tanstack%2Freact-query%2F-%2Freact-query-4.29.17.tgz"],\
@@ -8799,6 +8828,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@graphql-codegen/add", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fadd%2F-%2Fadd-4.0.1.tgz"],\
             ["@graphql-codegen/cli", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fcli%2F-%2Fcli-4.0.1.tgz"],\
             ["@graphql-codegen/typescript", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript%2F-%2Ftypescript-4.0.1.tgz"],\
+            ["@graphql-codegen/typescript-msw", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:1.1.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-msw%2F-%2Ftypescript-msw-1.1.6.tgz"],\
             ["@graphql-codegen/typescript-operations", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-operations%2F-%2Ftypescript-operations-4.0.1.tgz"],\
             ["@graphql-codegen/typescript-react-query", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-react-query%2F-%2Ftypescript-react-query-4.1.0.tgz"],\
             ["@tanstack/react-query", "virtual:2bae379cd6dae54b20bb7a662df6186d144f6a626a97ec9e822aec1f041b3de814c49e44566dd42f57ff2d0607a3b2858ce1677c87e9ae7042d80f30356f355a#npm:4.29.17::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40tanstack%2Freact-query%2F-%2Freact-query-4.29.17.tgz"],\
@@ -8828,6 +8858,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@graphql-codegen/add", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fadd%2F-%2Fadd-4.0.1.tgz"],\
             ["@graphql-codegen/cli", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fcli%2F-%2Fcli-4.0.1.tgz"],\
             ["@graphql-codegen/typescript", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript%2F-%2Ftypescript-4.0.1.tgz"],\
+            ["@graphql-codegen/typescript-msw", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:1.1.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-msw%2F-%2Ftypescript-msw-1.1.6.tgz"],\
             ["@graphql-codegen/typescript-operations", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-operations%2F-%2Ftypescript-operations-4.0.1.tgz"],\
             ["@graphql-codegen/typescript-react-query", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-react-query%2F-%2Ftypescript-react-query-4.1.0.tgz"],\
             ["@tanstack/react-query", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.29.17::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40tanstack%2Freact-query%2F-%2Freact-query-4.29.17.tgz"],\
@@ -8857,6 +8888,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@graphql-codegen/add", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fadd%2F-%2Fadd-4.0.1.tgz"],\
             ["@graphql-codegen/cli", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fcli%2F-%2Fcli-4.0.1.tgz"],\
             ["@graphql-codegen/typescript", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript%2F-%2Ftypescript-4.0.1.tgz"],\
+            ["@graphql-codegen/typescript-msw", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:1.1.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-msw%2F-%2Ftypescript-msw-1.1.6.tgz"],\
             ["@graphql-codegen/typescript-operations", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-operations%2F-%2Ftypescript-operations-4.0.1.tgz"],\
             ["@graphql-codegen/typescript-react-query", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-react-query%2F-%2Ftypescript-react-query-4.1.0.tgz"],\
             ["@tanstack/react-query", "virtual:b504e789f8269880145d8243189f1e4fc2a0f7a81424169dfc6f2312cd71f2d0d0789f9a4fc94fc40f78c4e94142d2561b1c0db22370c825d0723dde09142740#npm:4.29.17::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40tanstack%2Freact-query%2F-%2Freact-query-4.29.17.tgz"],\
@@ -8886,6 +8918,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["@graphql-codegen/add", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fadd%2F-%2Fadd-4.0.1.tgz"],\
             ["@graphql-codegen/cli", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Fcli%2F-%2Fcli-4.0.1.tgz"],\
             ["@graphql-codegen/typescript", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript%2F-%2Ftypescript-4.0.1.tgz"],\
+            ["@graphql-codegen/typescript-msw", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:1.1.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-msw%2F-%2Ftypescript-msw-1.1.6.tgz"],\
             ["@graphql-codegen/typescript-operations", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-operations%2F-%2Ftypescript-operations-4.0.1.tgz"],\
             ["@graphql-codegen/typescript-react-query", "virtual:9e4bf2363b45745fe911c90a49a79e4d447f4ac61ded38f099ba69ca4ec5dd41ba4db36615981fb6d9df45c52bb604ac8088949216b198d95721a12708e68a97#npm:4.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-react-query%2F-%2Ftypescript-react-query-4.1.0.tgz"],\
             ["@tanstack/react-query", "virtual:46fc6faaec58571090e30e34692911b4e1abbaa431b52c2cb730745fcbf355d9178ef591e75901d89ff98228b359a5757937de2d69117ec94b616b228e28a2be#npm:4.29.17::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40tanstack%2Freact-query%2F-%2Freact-query-4.29.17.tgz"],\

--- a/app/examples/react-16/src/components/CounterConnectedTest.jsx
+++ b/app/examples/react-16/src/components/CounterConnectedTest.jsx
@@ -5,6 +5,11 @@ const { REACT_APP_PROPEL_ACCESS_TOKEN, REACT_APP_METRIC_UNIQUE_NAME_1 } = proces
 
 export function CounterConnectedTest() {
   const [fontColor, setFontColor] = React.useState('#000')
+  const [refetchInterval, setRefetchInterval] = React.useState(undefined)
+
+  const handleSwitchRefetchInterval = () => {
+    setRefetchInterval(refetchInterval ? undefined : 1000)
+  }
 
   return (
     <div className="p-4 border-2 bg-neutral-100 border-slate-600 rounded m-3">
@@ -17,7 +22,9 @@ export function CounterConnectedTest() {
             timeRange: {
               relative: RelativeTimeRange.LastNDays,
               n: 30
-            }
+            },
+            refetchInterval,
+            retry: false
           }}
           styles={{ font: { size: '3rem', color: fontColor } }}
         />
@@ -28,6 +35,9 @@ export function CounterConnectedTest() {
           type="color"
           onChange={(event) => setFontColor(event.target.value)}
         />
+        <button className="border-2 bg-white p-1 h-9" onClick={handleSwitchRefetchInterval}>
+          Refetch Interval: {refetchInterval ? 'On 1000ms' : 'Off'}
+        </button>
       </div>
     </div>
   )

--- a/app/examples/react-16/src/components/LeaderboardConnectedTest.jsx
+++ b/app/examples/react-16/src/components/LeaderboardConnectedTest.jsx
@@ -1,63 +1,43 @@
 import React from 'react'
-import { Leaderboard, RelativeTimeRange } from '@propeldata/react-leaderboard'
+import { Counter, RelativeTimeRange } from '@propeldata/react-counter'
 
-const {
-  REACT_APP_PROPEL_ACCESS_TOKEN,
-  REACT_APP_METRIC_UNIQUE_NAME_1,
-  REACT_APP_DIMENSION_1,
-  REACT_APP_DIMENSION_2,
-  REACT_APP_DIMENSION_3
-} = process.env
+const { REACT_APP_PROPEL_ACCESS_TOKEN, REACT_APP_METRIC_UNIQUE_NAME_1 } = process.env
 
-export function LeaderboardConnectedTest() {
-  const [barsColor, setBarsColor] = React.useState('#ccc')
-  const [chartType, setChartType] = React.useState('bar')
+export function CounterConnectedTest() {
+  const [fontColor, setFontColor] = React.useState('#000')
+  const [refetchInterval, setRefetchInterval] = React.useState(undefined)
+
+  const handleSwitchRefetchInterval = () => {
+    setRefetchInterval(refetchInterval ? undefined : 1000)
+  }
 
   return (
     <div className="p-4 border-2 bg-neutral-100 border-slate-600 rounded m-3">
-      <h2 className="text-2xl">Leaderboard Connected</h2>
-      <Leaderboard
-        query={{
-          accessToken: REACT_APP_PROPEL_ACCESS_TOKEN,
-          dimensions: [
-            {
-              columnName: REACT_APP_DIMENSION_1
+      <h2 className="text-2xl">Counter Connected</h2>
+      <div className="h-60 flex justify-center items-center">
+        <Counter
+          query={{
+            accessToken: REACT_APP_PROPEL_ACCESS_TOKEN,
+            metric: REACT_APP_METRIC_UNIQUE_NAME_1,
+            timeRange: {
+              relative: RelativeTimeRange.LastNDays,
+              n: 30
             },
-            {
-              columnName: REACT_APP_DIMENSION_2
-            },
-            {
-              columnName: REACT_APP_DIMENSION_3
-            }
-          ],
-          metric: REACT_APP_METRIC_UNIQUE_NAME_1,
-          rowLimit: 8,
-          timeRange: {
-            relative: RelativeTimeRange.LastNDays,
-            n: 30
-          }
-        }}
-        variant={chartType}
-        styles={{
-          bar: { backgroundColor: barsColor },
-          table: { height: '200px', backgroundColor: '#f5f5f5', header: { backgroundColor: '#f5f5f5' } },
-          canvas: { backgroundColor: '#f5f5f5' }
-        }}
-      />
+            refetchInterval,
+            retry: false
+          }}
+          styles={{ font: { size: '3rem', color: fontColor } }}
+        />
+      </div>
       <div className="flex items-center gap-2 mt-1">
         <input
           className="border-2 bg-white p-1 h-9"
           type="color"
-          onChange={(event) => setBarsColor(event.target.value)}
+          onChange={(event) => setFontColor(event.target.value)}
         />
-        <select
-          className="border-2 bg-white p-1 h-9 cursor-pointer"
-          value={chartType}
-          onChange={(event) => setChartType(event.target.value)}
-        >
-          <option value="bar">Bar</option>
-          <option value="table">Table</option>
-        </select>
+        <button className="border-2 bg-white p-1 h-9" onClick={handleSwitchRefetchInterval}>
+          Refetch Interval: {refetchInterval ? 'On 1000ms' : 'Off'}
+        </button>
       </div>
     </div>
   )

--- a/app/examples/react-16/src/components/TimeSeriesConnectedTest.jsx
+++ b/app/examples/react-16/src/components/TimeSeriesConnectedTest.jsx
@@ -7,6 +7,11 @@ export function TimeSeriesConnectedTest() {
   const [barsColor, setBarsColor] = React.useState('#ccc')
   const [chartType, setChartType] = React.useState('bar')
   const [pointStyle, setPointStyle] = React.useState('cross')
+  const [refetchInterval, setRefetchInterval] = React.useState(undefined)
+
+  const handleSwitchRefetchInterval = () => {
+    setRefetchInterval(refetchInterval ? undefined : 1000)
+  }
 
   return (
     <div className="p-4 border-2 bg-neutral-100 border-slate-600 rounded m-3">
@@ -19,7 +24,9 @@ export function TimeSeriesConnectedTest() {
             relative: RelativeTimeRange.LastNDays,
             n: 30
           },
-          granularity: TimeSeriesGranularity.Day
+          granularity: TimeSeriesGranularity.Day,
+          refetchInterval,
+          retry: false
         }}
         variant={chartType}
         styles={{
@@ -47,6 +54,9 @@ export function TimeSeriesConnectedTest() {
           onClick={() => setPointStyle(pointStyle === 'cross' ? 'triangle' : 'cross')}
         >
           Switch point style
+        </button>
+        <button className="border-2 bg-white p-1 h-9" onClick={handleSwitchRefetchInterval}>
+          Refetch Interval: {refetchInterval ? 'On 1000ms' : 'Off'}
         </button>
       </div>
     </div>

--- a/app/examples/react-17/src/components/CounterConnectedTest.jsx
+++ b/app/examples/react-17/src/components/CounterConnectedTest.jsx
@@ -5,6 +5,11 @@ const { REACT_APP_PROPEL_ACCESS_TOKEN, REACT_APP_METRIC_UNIQUE_NAME_1 } = proces
 
 export function CounterConnectedTest() {
   const [fontColor, setFontColor] = React.useState('#000')
+  const [refetchInterval, setRefetchInterval] = React.useState(undefined)
+
+  const handleSwitchRefetchInterval = () => {
+    setRefetchInterval(refetchInterval ? undefined : 1000)
+  }
 
   return (
     <div className="p-4 border-2 bg-neutral-100 border-slate-600 rounded m-3">
@@ -17,7 +22,9 @@ export function CounterConnectedTest() {
             timeRange: {
               relative: RelativeTimeRange.LastNDays,
               n: 30
-            }
+            },
+            refetchInterval,
+            retry: false
           }}
           styles={{ font: { size: '3rem', color: fontColor } }}
         />
@@ -28,6 +35,9 @@ export function CounterConnectedTest() {
           type="color"
           onChange={(event) => setFontColor(event.target.value)}
         />
+        <button className="border-2 bg-white p-1 h-9" onClick={handleSwitchRefetchInterval}>
+          Refetch Interval: {refetchInterval ? 'On 1000ms' : 'Off'}
+        </button>
       </div>
     </div>
   )

--- a/app/examples/react-17/src/components/LeaderboardConnectedTest.jsx
+++ b/app/examples/react-17/src/components/LeaderboardConnectedTest.jsx
@@ -1,63 +1,43 @@
 import React from 'react'
-import { Leaderboard, RelativeTimeRange } from '@propeldata/react-leaderboard'
+import { Counter, RelativeTimeRange } from '@propeldata/react-counter'
 
-const {
-  REACT_APP_PROPEL_ACCESS_TOKEN,
-  REACT_APP_METRIC_UNIQUE_NAME_1,
-  REACT_APP_DIMENSION_1,
-  REACT_APP_DIMENSION_2,
-  REACT_APP_DIMENSION_3
-} = process.env
+const { REACT_APP_PROPEL_ACCESS_TOKEN, REACT_APP_METRIC_UNIQUE_NAME_1 } = process.env
 
-export function LeaderboardConnectedTest() {
-  const [barsColor, setBarsColor] = React.useState('#ccc')
-  const [chartType, setChartType] = React.useState('bar')
+export function CounterConnectedTest() {
+  const [fontColor, setFontColor] = React.useState('#000')
+  const [refetchInterval, setRefetchInterval] = React.useState(undefined)
+
+  const handleSwitchRefetchInterval = () => {
+    setRefetchInterval(refetchInterval ? undefined : 1000)
+  }
 
   return (
     <div className="p-4 border-2 bg-neutral-100 border-slate-600 rounded m-3">
-      <h2 className="text-2xl">Leaderboard Connected</h2>
-      <Leaderboard
-        query={{
-          accessToken: REACT_APP_PROPEL_ACCESS_TOKEN,
-          dimensions: [
-            {
-              columnName: REACT_APP_DIMENSION_1
+      <h2 className="text-2xl">Counter Connected</h2>
+      <div className="h-60 flex justify-center items-center">
+        <Counter
+          query={{
+            accessToken: REACT_APP_PROPEL_ACCESS_TOKEN,
+            metric: REACT_APP_METRIC_UNIQUE_NAME_1,
+            timeRange: {
+              relative: RelativeTimeRange.LastNDays,
+              n: 30
             },
-            {
-              columnName: REACT_APP_DIMENSION_2
-            },
-            {
-              columnName: REACT_APP_DIMENSION_3
-            }
-          ],
-          metric: REACT_APP_METRIC_UNIQUE_NAME_1,
-          rowLimit: 8,
-          timeRange: {
-            relative: RelativeTimeRange.LastNDays,
-            n: 30
-          }
-        }}
-        variant={chartType}
-        styles={{
-          bar: { backgroundColor: barsColor },
-          table: { height: '200px', backgroundColor: '#f5f5f5', header: { backgroundColor: '#f5f5f5' } },
-          canvas: { backgroundColor: '#f5f5f5' }
-        }}
-      />
+            refetchInterval,
+            retry: false
+          }}
+          styles={{ font: { size: '3rem', color: fontColor } }}
+        />
+      </div>
       <div className="flex items-center gap-2 mt-1">
         <input
           className="border-2 bg-white p-1 h-9"
           type="color"
-          onChange={(event) => setBarsColor(event.target.value)}
+          onChange={(event) => setFontColor(event.target.value)}
         />
-        <select
-          className="border-2 bg-white p-1 h-9 cursor-pointer"
-          value={chartType}
-          onChange={(event) => setChartType(event.target.value)}
-        >
-          <option value="bar">Bar</option>
-          <option value="table">Table</option>
-        </select>
+        <button className="border-2 bg-white p-1 h-9" onClick={handleSwitchRefetchInterval}>
+          Refetch Interval: {refetchInterval ? 'On 1000ms' : 'Off'}
+        </button>
       </div>
     </div>
   )

--- a/app/examples/react-17/src/components/TimeSeriesConnectedTest.jsx
+++ b/app/examples/react-17/src/components/TimeSeriesConnectedTest.jsx
@@ -7,6 +7,11 @@ export function TimeSeriesConnectedTest() {
   const [barsColor, setBarsColor] = React.useState('#ccc')
   const [chartType, setChartType] = React.useState('bar')
   const [pointStyle, setPointStyle] = React.useState('cross')
+  const [refetchInterval, setRefetchInterval] = React.useState(undefined)
+
+  const handleSwitchRefetchInterval = () => {
+    setRefetchInterval(refetchInterval ? undefined : 1000)
+  }
 
   return (
     <div className="p-4 border-2 bg-neutral-100 border-slate-600 rounded m-3">
@@ -19,7 +24,9 @@ export function TimeSeriesConnectedTest() {
             relative: RelativeTimeRange.LastNDays,
             n: 30
           },
-          granularity: TimeSeriesGranularity.Day
+          granularity: TimeSeriesGranularity.Day,
+          refetchInterval,
+          retry: false
         }}
         variant={chartType}
         styles={{
@@ -47,6 +54,9 @@ export function TimeSeriesConnectedTest() {
           onClick={() => setPointStyle(pointStyle === 'cross' ? 'triangle' : 'cross')}
         >
           Switch point style
+        </button>
+        <button className="border-2 bg-white p-1 h-9" onClick={handleSwitchRefetchInterval}>
+          Refetch Interval: {refetchInterval ? 'On 1000ms' : 'Off'}
         </button>
       </div>
     </div>

--- a/app/examples/react-18/src/components/CounterConnectedTest.jsx
+++ b/app/examples/react-18/src/components/CounterConnectedTest.jsx
@@ -5,6 +5,11 @@ const { REACT_APP_PROPEL_ACCESS_TOKEN, REACT_APP_METRIC_UNIQUE_NAME_1 } = proces
 
 export function CounterConnectedTest() {
   const [fontColor, setFontColor] = React.useState('#000')
+  const [refetchInterval, setRefetchInterval] = React.useState(undefined)
+
+  const handleSwitchRefetchInterval = () => {
+    setRefetchInterval(refetchInterval ? undefined : 1000)
+  }
 
   return (
     <div className="p-4 border-2 bg-neutral-100 border-slate-600 rounded m-3">
@@ -17,7 +22,9 @@ export function CounterConnectedTest() {
             timeRange: {
               relative: RelativeTimeRange.LastNDays,
               n: 30
-            }
+            },
+            refetchInterval,
+            retry: false
           }}
           styles={{ font: { size: '3rem', color: fontColor } }}
         />
@@ -28,6 +35,9 @@ export function CounterConnectedTest() {
           type="color"
           onChange={(event) => setFontColor(event.target.value)}
         />
+        <button className="border-2 bg-white p-1 h-9" onClick={handleSwitchRefetchInterval}>
+          Refetch Interval: {refetchInterval ? 'On 1000ms' : 'Off'}
+        </button>
       </div>
     </div>
   )

--- a/app/examples/react-18/src/components/LeaderboardConnectedTest.jsx
+++ b/app/examples/react-18/src/components/LeaderboardConnectedTest.jsx
@@ -13,6 +13,12 @@ export function LeaderboardConnectedTest() {
   const [barsColor, setBarsColor] = React.useState('#ccc')
   const [chartType, setChartType] = React.useState('bar')
 
+  const [refetchInterval, setRefetchInterval] = React.useState(undefined)
+
+  const handleSwitchRefetchInterval = () => {
+    setRefetchInterval(refetchInterval ? undefined : 1000)
+  }
+
   return (
     <div className="p-4 border-2 bg-neutral-100 border-slate-600 rounded m-3">
       <h2 className="text-2xl">Leaderboard Connected</h2>
@@ -35,7 +41,9 @@ export function LeaderboardConnectedTest() {
           timeRange: {
             relative: RelativeTimeRange.LastNDays,
             n: 30
-          }
+          },
+          refetchInterval,
+          retry: false
         }}
         variant={chartType}
         styles={{
@@ -58,6 +66,9 @@ export function LeaderboardConnectedTest() {
           <option value="bar">Bar</option>
           <option value="table">Table</option>
         </select>
+        <button className="border-2 bg-white p-1 h-9" onClick={handleSwitchRefetchInterval}>
+          Refetch Interval: {refetchInterval ? 'On 1000ms' : 'Off'}
+        </button>
       </div>
     </div>
   )

--- a/app/examples/react-18/src/components/TimeSeriesConnectedTest.jsx
+++ b/app/examples/react-18/src/components/TimeSeriesConnectedTest.jsx
@@ -7,6 +7,11 @@ export function TimeSeriesConnectedTest() {
   const [barsColor, setBarsColor] = React.useState('#ccc')
   const [chartType, setChartType] = React.useState('bar')
   const [pointStyle, setPointStyle] = React.useState('cross')
+  const [refetchInterval, setRefetchInterval] = React.useState(undefined)
+
+  const handleSwitchRefetchInterval = () => {
+    setRefetchInterval(refetchInterval ? undefined : 1000)
+  }
 
   return (
     <div className="p-4 border-2 bg-neutral-100 border-slate-600 rounded m-3">
@@ -19,7 +24,9 @@ export function TimeSeriesConnectedTest() {
             relative: RelativeTimeRange.LastNDays,
             n: 30
           },
-          granularity: TimeSeriesGranularity.Day
+          granularity: TimeSeriesGranularity.Day,
+          refetchInterval,
+          retry: false
         }}
         variant={chartType}
         styles={{
@@ -47,6 +54,9 @@ export function TimeSeriesConnectedTest() {
           onClick={() => setPointStyle(pointStyle === 'cross' ? 'triangle' : 'cross')}
         >
           Switch point style
+        </button>
+        <button className="border-2 bg-white p-1 h-9" onClick={handleSwitchRefetchInterval}>
+          Refetch Interval: {refetchInterval ? 'On 1000ms' : 'Off'}
         </button>
       </div>
     </div>

--- a/packages/core/graphql/codegen.yml
+++ b/packages/core/graphql/codegen.yml
@@ -14,4 +14,4 @@ generates:
       # https://github.com/dotansimha/graphql-code-generator/issues/9046
       content:
         - // @ts-nocheck
-      fetcher: graphql-request
+      fetcher: fetch

--- a/packages/core/graphql/codegen.yml
+++ b/packages/core/graphql/codegen.yml
@@ -15,3 +15,27 @@ generates:
       content:
         - // @ts-nocheck
       fetcher: fetch
+  ../../react/counter/src/__test__/mockHandlers.ts:
+    schema: public.graphql
+    documents:
+      - ./**/*.graphql
+    plugins:
+      - typescript
+      - typescript-msw
+      - typescript-operations
+  ../../react/leaderboard/src/__test__/mockHandlers.ts:
+    schema: public.graphql
+    documents:
+      - ./**/*.graphql
+    plugins:
+      - typescript
+      - typescript-msw
+      - typescript-operations
+  ../../react/time-series/src/__test__/mockHandlers.ts:
+    schema: public.graphql
+    documents:
+      - ./**/*.graphql
+    plugins:
+      - typescript
+      - typescript-msw
+      - typescript-operations

--- a/packages/core/graphql/package.json
+++ b/packages/core/graphql/package.json
@@ -17,8 +17,7 @@
   "dependencies": {
     "@tanstack/react-query": "^4.29.17",
     "dotenv": "^16.0.3",
-    "graphql": "^16.6.0",
-    "graphql-request": "^6.1.0"
+    "graphql": "^16.6.0"
   },
   "peerDependencies": {
     "graphql": "^16.6",

--- a/packages/core/graphql/package.json
+++ b/packages/core/graphql/package.json
@@ -28,6 +28,7 @@
     "@graphql-codegen/add": "^4.0.0",
     "@graphql-codegen/cli": "^4.0.1",
     "@graphql-codegen/typescript": "^4.0.1",
+    "@graphql-codegen/typescript-msw": "^1.1.6",
     "@graphql-codegen/typescript-operations": "^4.0.1",
     "@graphql-codegen/typescript-react-query": "^4.1.0",
     "react": "^18.2.0",

--- a/packages/core/graphql/src/index.ts
+++ b/packages/core/graphql/src/index.ts
@@ -1,3 +1,5 @@
+export { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
 export * from './generated'
 
 // export const PROPEL_GRAPHQL_API_ENDPOINT = process.env.PROPEL_GRAPHQL_API_ENDPOINT as string

--- a/packages/react/counter/jest-environment-jsdom.cjs
+++ b/packages/react/counter/jest-environment-jsdom.cjs
@@ -12,6 +12,9 @@ class JSDOMEnvironment extends OriginalJSDOMEnvironment {
     const { global } = super(...args)
     if (!global.TextEncoder) global.TextEncoder = TextEncoder
     if (!global.TextDecoder) global.TextDecoder = TextDecoder
+    if (!global.fetch) global.fetch = fetch
+    if (!global.Request) global.Request = Request
+    if (!global.Response) global.Response = Response
   }
 }
 

--- a/packages/react/counter/package.json
+++ b/packages/react/counter/package.json
@@ -20,8 +20,7 @@
     "@propeldata/ui-kit-components": "workspace:^0.31.0-rc.4",
     "@propeldata/ui-kit-graphql": "workspace:^0.31.0-rc.4",
     "@propeldata/ui-kit-plugins": "workspace:^0.31.0-rc.4",
-    "graphql": "^16.0.1",
-    "graphql-request": "^6.1.0"
+    "graphql": "^16.0.1"
   },
   "devDependencies": {
     "@swc/core": "^1.3.68",

--- a/packages/react/counter/src/Container.tsx
+++ b/packages/react/counter/src/Container.tsx
@@ -1,15 +1,20 @@
 import React from 'react'
 import { ErrorBoundary } from '@propeldata/ui-kit-components'
+import { QueryClient, QueryClientProvider } from '@propeldata/ui-kit-graphql'
 
 import { Counter, CounterProps } from './Counter'
 import { ErrorFallback } from './ErrorFallback'
+
+const queryClient = new QueryClient()
 
 export function Container(props: CounterProps) {
   const { styles } = props
 
   return (
-    <ErrorBoundary fallback={<ErrorFallback styles={styles} />}>
-      <Counter {...props} />
-    </ErrorBoundary>
+    <QueryClientProvider client={queryClient}>
+      <ErrorBoundary fallback={<ErrorFallback styles={styles} />}>
+        <Counter {...props} />
+      </ErrorBoundary>
+    </QueryClientProvider>
   )
 }

--- a/packages/react/counter/src/Counter.tsx
+++ b/packages/react/counter/src/Counter.tsx
@@ -46,7 +46,16 @@ export interface CounterProps extends React.ComponentProps<'span'> {
 }
 
 export function Counter(props: CounterProps) {
-  const { value: staticValue, query, prefixValue, sufixValue, styles, loading = false, localize, ...rest } = props
+  const {
+    value: staticValue,
+    query,
+    prefixValue,
+    sufixValue,
+    styles,
+    loading: isLoadingStatic = false,
+    localize,
+    ...rest
+  } = props
 
   /**
    * If the user passes `value` attribute, it
@@ -59,7 +68,7 @@ export function Counter(props: CounterProps) {
   const counterRef = React.useRef<HTMLSpanElement>(null)
 
   const {
-    isLoading,
+    isInitialLoading: isLoadingQuery,
     error,
     data: fetchedValue
   } = useCounterQuery(
@@ -113,16 +122,16 @@ export function Counter(props: CounterProps) {
       setPropsMismatch(false)
     }
 
-    if (!loading) {
+    if (!isLoadingStatic) {
       handlePropsMismatch()
     }
-  }, [isStatic, value, query, loading])
+  }, [isStatic, value, query, isLoadingStatic])
 
   if (error || propsMismatch) {
     return <ErrorFallback styles={styles} />
   }
 
-  if (((isStatic && loading) || (!isStatic && isLoading)) && !counterRef.current) {
+  if (((isStatic && isLoadingStatic) || (!isStatic && isLoadingQuery)) && !counterRef.current) {
     return <Loader styles={styles} />
   }
 
@@ -130,7 +139,7 @@ export function Counter(props: CounterProps) {
     <span
       ref={counterRef}
       style={{
-        opacity: isLoading || loading ? '0.3' : '1',
+        opacity: isLoadingQuery || isLoadingStatic ? '0.3' : '1',
         transition: 'opacity 0.2s ease-in-out'
       }}
       {...rest}

--- a/packages/react/counter/src/Counter.tsx
+++ b/packages/react/counter/src/Counter.tsx
@@ -38,6 +38,8 @@ export interface CounterProps extends React.ComponentProps<'span'> {
     propeller?: Propeller
     /** Interval in milliseconds for refetching the data */
     refetchInterval?: number
+    /** Whether to retry on errors. */
+    retry?: boolean
   }
   /** When true, shows a skeleton loader */
   loading?: boolean
@@ -65,6 +67,7 @@ export function Counter(props: CounterProps) {
       endpoint: PROPEL_GRAPHQL_API_ENDPOINT,
       fetchParams: {
         headers: {
+          'content-type': 'application/json',
           authorization: `Bearer ${query?.accessToken}`
         }
       }
@@ -83,12 +86,13 @@ export function Counter(props: CounterProps) {
       }
     },
     {
-      refetchInterval: props.query?.refetchInterval,
+      refetchInterval: query?.refetchInterval,
+      retry: query?.retry,
       enabled: !isStatic
     }
   )
 
-  const value = isStatic ? staticValue : fetchedValue.counter.value
+  const value = isStatic ? staticValue : fetchedValue?.counter?.value
 
   React.useEffect(() => {
     function handlePropsMismatch() {
@@ -118,7 +122,7 @@ export function Counter(props: CounterProps) {
     return <ErrorFallback styles={styles} />
   }
 
-  if ((isLoading || loading || (staticValue === undefined && !isStatic)) && !counterRef.current) {
+  if (((isStatic && loading) || (!isStatic && isLoading)) && !counterRef.current) {
     return <Loader styles={styles} />
   }
 

--- a/packages/react/counter/src/__test__/Counter.test.tsx
+++ b/packages/react/counter/src/__test__/Counter.test.tsx
@@ -62,4 +62,10 @@ describe('Counter', () => {
 
     await dom.findByRole('img')
   })
+
+  it('Should show error fallback on props mismatch', async () => {
+    dom = render(<Counter />)
+
+    await dom.findByRole('img')
+  })
 })

--- a/packages/react/counter/src/__test__/Counter.test.tsx
+++ b/packages/react/counter/src/__test__/Counter.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, waitFor } from '@testing-library/react'
+import { render } from '@testing-library/react'
 
 import { Counter, RelativeTimeRange } from '@/counter'
 import { Dom } from '@/testing'
@@ -45,9 +45,7 @@ describe('Counter', () => {
       />
     )
 
-    await waitFor(async () => {
-      await dom.findByText('-')
-    })
+    await dom.findByText('-')
   })
 
   it('Should show error fallback when request fails', async () => {
@@ -56,13 +54,12 @@ describe('Counter', () => {
         query={{
           metric: 'should-fail',
           accessToken: 'test-token',
-          timeRange: { relative: RelativeTimeRange.LastNDays, n: 30 }
+          timeRange: { relative: RelativeTimeRange.LastNDays, n: 30 },
+          retry: false
         }}
       />
     )
 
-    await waitFor(async () => {
-      await dom.findByRole('img')
-    })
+    await dom.findByRole('img')
   })
 })

--- a/packages/react/counter/src/__test__/mswHandlers.ts
+++ b/packages/react/counter/src/__test__/mswHandlers.ts
@@ -1,11 +1,10 @@
-import { graphql } from 'msw'
-
 import { server } from '@/testing/mocks/server'
 
 import { counter } from './mockData'
+import { mockCounterQuery } from './mockHandlers'
 
 const handlers = [
-  graphql.query('Counter', (req, res, ctx) => {
+  mockCounterQuery((req, res, ctx) => {
     const { metricName } = req.variables.counterInput
 
     if (metricName === 'lack-of-data') {

--- a/packages/react/leaderboard/jest-environment-jsdom.cjs
+++ b/packages/react/leaderboard/jest-environment-jsdom.cjs
@@ -12,6 +12,9 @@ class JSDOMEnvironment extends OriginalJSDOMEnvironment {
     const { global } = super(...args)
     if (!global.TextEncoder) global.TextEncoder = TextEncoder
     if (!global.TextDecoder) global.TextDecoder = TextDecoder
+    if (!global.fetch) global.fetch = fetch
+    if (!global.Request) global.Request = Request
+    if (!global.Response) global.Response = Response
   }
 }
 

--- a/packages/react/leaderboard/package.json
+++ b/packages/react/leaderboard/package.json
@@ -21,8 +21,7 @@
     "@propeldata/ui-kit-graphql": "workspace:^0.31.0-rc.4",
     "@propeldata/ui-kit-plugins": "workspace:^0.31.0-rc.4",
     "chart.js": "^4.1.2",
-    "graphql": "^16.6.0",
-    "graphql-request": "^6.1.0"
+    "graphql": "^16.6.0"
   },
   "devDependencies": {
     "@juggle/resize-observer": "^3.4.0",

--- a/packages/react/leaderboard/src/Container.tsx
+++ b/packages/react/leaderboard/src/Container.tsx
@@ -1,15 +1,20 @@
 import React from 'react'
 import { ErrorBoundary } from '@propeldata/ui-kit-components'
+import { QueryClient, QueryClientProvider } from '@propeldata/ui-kit-graphql'
 
 import { Leaderboard, LeaderboardProps } from './Leaderboard'
 import { ErrorFallback } from './ErrorFallback'
+
+const queryClient = new QueryClient()
 
 export function Container(props: LeaderboardProps) {
   const { styles } = props
 
   return (
-    <ErrorBoundary fallback={<ErrorFallback styles={styles} />}>
-      <Leaderboard {...props} />
-    </ErrorBoundary>
+    <QueryClientProvider client={queryClient}>
+      <ErrorBoundary fallback={<ErrorFallback styles={styles} />}>
+        <Leaderboard {...props} />
+      </ErrorBoundary>
+    </QueryClientProvider>
   )
 }

--- a/packages/react/leaderboard/src/Leaderboard.tsx
+++ b/packages/react/leaderboard/src/Leaderboard.tsx
@@ -77,6 +77,9 @@ export interface LeaderboardProps extends ErrorFallbackProps, React.ComponentPro
 
     /** Interval in milliseconds for refetching the data */
     refetchInterval?: number
+
+    /** Whether to retry on errors. */
+    retry?: boolean
   }
 }
 
@@ -198,6 +201,7 @@ export function Leaderboard(props: LeaderboardProps) {
       endpoint: PROPEL_GRAPHQL_API_ENDPOINT,
       fetchParams: {
         headers: {
+          'content-type': 'application/json',
           authorization: `Bearer ${query?.accessToken}`
         }
       }
@@ -220,6 +224,7 @@ export function Leaderboard(props: LeaderboardProps) {
     },
     {
       refetchInterval: query?.refetchInterval,
+      retry: query?.retry,
       enabled: !isStatic
     }
   )
@@ -311,7 +316,7 @@ export function Leaderboard(props: LeaderboardProps) {
 
   const isNoContainerRef = (variant === 'bar' && !canvasRef.current) || (variant === 'table' && !tableRef.current)
 
-  if ((isLoading || loading || (fetchedData === undefined && !isStatic)) && isNoContainerRef) {
+  if (((isStatic && loading) || (!isStatic && isLoading)) && isNoContainerRef) {
     destroyChart()
     return <Loader styles={styles} />
   }

--- a/packages/react/leaderboard/src/Leaderboard.tsx
+++ b/packages/react/leaderboard/src/Leaderboard.tsx
@@ -84,7 +84,7 @@ export interface LeaderboardProps extends ErrorFallbackProps, React.ComponentPro
 }
 
 export function Leaderboard(props: LeaderboardProps) {
-  const { variant = 'bar', styles, headers, rows, query, error, loading = false, ...rest } = props
+  const { variant = 'bar', styles, headers, rows, query, error, loading: isLoadingStatic = false, ...rest } = props
 
   const [propsMismatch, setPropsMismatch] = React.useState(false)
 
@@ -193,7 +193,7 @@ export function Leaderboard(props: LeaderboardProps) {
   }
 
   const {
-    isLoading,
+    isInitialLoading: isLoadingQuery,
     error: hasError,
     data: fetchedData
   } = useLeaderboardQuery(
@@ -230,7 +230,7 @@ export function Leaderboard(props: LeaderboardProps) {
   )
 
   const loadingStyles = {
-    opacity: isLoading || loading ? '0.3' : '1',
+    opacity: isLoadingQuery || isLoadingStatic ? '0.3' : '1',
     transition: 'opacity 0.2s ease-in-out'
   }
 
@@ -262,16 +262,16 @@ export function Leaderboard(props: LeaderboardProps) {
       setPropsMismatch(false)
     }
 
-    if (!loading) {
+    if (!isLoadingStatic) {
       handlePropsMismatch()
     }
-  }, [isStatic, headers, rows, query, loading])
+  }, [isStatic, headers, rows, query, isLoadingStatic])
 
   React.useEffect(() => {
     if (isStatic) {
       renderChart({ headers, rows })
     }
-  }, [isStatic, loading, styles, variant, headers, rows, renderChart])
+  }, [isStatic, isLoadingStatic, styles, variant, headers, rows, renderChart])
 
   React.useEffect(() => {
     if (fetchedData && !isStatic) {
@@ -316,7 +316,7 @@ export function Leaderboard(props: LeaderboardProps) {
 
   const isNoContainerRef = (variant === 'bar' && !canvasRef.current) || (variant === 'table' && !tableRef.current)
 
-  if (((isStatic && loading) || (!isStatic && isLoading)) && isNoContainerRef) {
+  if (((isStatic && isLoadingStatic) || (!isStatic && isLoadingQuery)) && isNoContainerRef) {
     destroyChart()
     return <Loader styles={styles} />
   }

--- a/packages/react/leaderboard/src/Leaderboard.tsx
+++ b/packages/react/leaderboard/src/Leaderboard.tsx
@@ -245,6 +245,7 @@ export function Leaderboard(props: LeaderboardProps) {
       if (isStatic && (!headers || !rows)) {
         // console.error('InvalidPropsError: When passing the data via props you must pass both `headers` and `rows`') we will set logs as a feature later
         setPropsMismatch(true)
+
         return
       }
 
@@ -259,13 +260,18 @@ export function Leaderboard(props: LeaderboardProps) {
         return
       }
 
+      if (variant !== 'bar' && variant !== 'table') {
+        // console.error('InvalidPropsError: `variant` prop must be either `bar` or `table`') we will set logs as a feature later
+        setPropsMismatch(false)
+      }
+
       setPropsMismatch(false)
     }
 
     if (!isLoadingStatic) {
       handlePropsMismatch()
     }
-  }, [isStatic, headers, rows, query, isLoadingStatic])
+  }, [isStatic, headers, rows, query, isLoadingStatic, variant])
 
   React.useEffect(() => {
     if (isStatic) {
@@ -278,18 +284,6 @@ export function Leaderboard(props: LeaderboardProps) {
       renderChart(fetchedData.leaderboard)
     }
   }, [fetchedData, styles, variant, isStatic, renderChart])
-
-  React.useEffect(() => {
-    try {
-      if (variant !== 'bar' && variant !== 'table') {
-        // console.error('InvalidPropsError: `variant` prop must be either `bar` or `table`') we will set logs as a feature later
-        throw new Error('InvalidPropsError')
-      }
-      setPropsMismatch(false)
-    } catch {
-      setPropsMismatch(true)
-    }
-  }, [variant])
 
   React.useEffect(() => {
     if (variant === 'table') {

--- a/packages/react/leaderboard/src/__test__/Leaderboard.test.tsx
+++ b/packages/react/leaderboard/src/__test__/Leaderboard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Chart } from 'chart.js'
-import { render } from '@testing-library/react'
+import { render, waitFor } from '@testing-library/react'
 
 import { Dom } from '@/testing'
 import { Leaderboard, RelativeTimeRange } from '@/leaderboard'
@@ -62,5 +62,42 @@ describe('Leaderboard', () => {
 
     expect(chartData).toEqual(resultingRows)
     expect(chartLabels).toEqual(resultingLabels)
+  })
+
+  it('should show error fallback when query fails', async () => {
+    dom = render(
+      <Leaderboard
+        query={{
+          accessToken: 'test-token',
+          metric: 'should-fail',
+          dimensions: [
+            {
+              columnName: 'test-column'
+            }
+          ],
+          rowLimit: 10,
+          timeRange: {
+            relative: RelativeTimeRange.LastNDays,
+            n: 30
+          },
+          retry: false
+        }}
+      />
+    )
+
+    await dom.findByText('Unable to connect')
+
+    await dom.findByText('Sorry we are not able to connect at this time due to a technical error.')
+  })
+
+  it('should show error fallback on props mismatch', async () => {
+    dom = render(<Leaderboard headers={['a', 'b', 'c']} />)
+
+    await waitFor(async () => {
+      await dom.findByText('Unable to connect')
+
+      // TODO: this message suggests that the error is due to a network issue when it's not, maybe we should think about changing the message depending on the error
+      await dom.findByText('Sorry we are not able to connect at this time due to a technical error.')
+    })
   })
 })

--- a/packages/react/leaderboard/src/__test__/mswHandlers.ts
+++ b/packages/react/leaderboard/src/__test__/mswHandlers.ts
@@ -1,11 +1,22 @@
-import { graphql } from 'msw'
-
 import { server } from '@/testing/mocks/server'
 
 import { leaderboard } from './mockData'
+import { mockLeaderboardQuery } from './mockHandlers'
 
 export const handlers = [
-  graphql.query('Leaderboard', (req, res, ctx) => {
+  mockLeaderboardQuery((req, res, ctx) => {
+    const { metricName } = req.variables.leaderboardInput
+
+    if (metricName === 'should-fail') {
+      return res(
+        ctx.errors([
+          {
+            message: 'Something went wrong'
+          }
+        ])
+      )
+    }
+
     return res(
       ctx.data({
         leaderboard

--- a/packages/react/time-series/jest-environment-jsdom.cjs
+++ b/packages/react/time-series/jest-environment-jsdom.cjs
@@ -12,6 +12,9 @@ class JSDOMEnvironment extends OriginalJSDOMEnvironment {
     const { global } = super(...args)
     if (!global.TextEncoder) global.TextEncoder = TextEncoder
     if (!global.TextDecoder) global.TextDecoder = TextDecoder
+    if (!global.fetch) global.fetch = fetch
+    if (!global.Request) global.Request = Request
+    if (!global.Response) global.Response = Response
   }
 }
 

--- a/packages/react/time-series/package.json
+++ b/packages/react/time-series/package.json
@@ -22,8 +22,7 @@
     "@propeldata/ui-kit-plugins": "workspace:^0.31.0-rc.4",
     "chart.js": "^4.2.1",
     "date-fns": "^2.29.3",
-    "graphql": "^16.6.0",
-    "graphql-request": "^6.1.0"
+    "graphql": "^16.6.0"
   },
   "devDependencies": {
     "@juggle/resize-observer": "^3.4.0",

--- a/packages/react/time-series/src/Container.tsx
+++ b/packages/react/time-series/src/Container.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
 import { ErrorBoundary } from '@propeldata/ui-kit-components'
+import { QueryClient, QueryClientProvider } from '@propeldata/ui-kit-graphql'
 
 import { TimeSeries, TimeSeriesProps } from './TimeSeries'
 import { ErrorFallback } from './ErrorFallback'
+
+const queryClient = new QueryClient()
 
 export function Container(props: TimeSeriesProps) {
   const { error, styles } = props
@@ -13,8 +16,10 @@ export function Container(props: TimeSeriesProps) {
   }
 
   return (
-    <ErrorBoundary fallback={<ErrorFallback {...errorProps} />}>
-      <TimeSeries {...props} />
-    </ErrorBoundary>
+    <QueryClientProvider client={queryClient}>
+      <ErrorBoundary fallback={<ErrorFallback {...errorProps} />}>
+        <TimeSeries {...props} />
+      </ErrorBoundary>
+    </QueryClientProvider>
   )
 }

--- a/packages/react/time-series/src/TimeSeries.tsx
+++ b/packages/react/time-series/src/TimeSeries.tsx
@@ -123,7 +123,7 @@ export function TimeSeries(props: TimeSeriesProps) {
     values,
     query,
     error,
-    loading = false,
+    loading: isLoadingStatic = false,
     labelFormatter,
     ariaLabel,
     role,
@@ -153,7 +153,7 @@ export function TimeSeries(props: TimeSeriesProps) {
   useSetupDefaultStyles(styles)
 
   const {
-    isLoading,
+    isInitialLoading: isLoadingQuery,
     error: hasError,
     data: serverData
   } = useTimeSeriesQuery(
@@ -287,17 +287,17 @@ export function TimeSeries(props: TimeSeriesProps) {
       setPropsMismatch(false)
     }
 
-    if (!loading) {
+    if (!isLoadingStatic) {
       handlePropsMismatch()
     }
-  }, [isStatic, labels, values, query, loading])
+  }, [isStatic, labels, values, query, isLoadingStatic])
 
   React.useEffect(() => {
     if (isStatic) {
       const formattedLabels = formatLabels({ labels, formatter: labelFormatter })
       renderChart({ labels: formattedLabels, values })
     }
-  }, [isStatic, loading, styles, variant, labels, values, labelFormatter, renderChart])
+  }, [isStatic, isLoadingStatic, styles, variant, labels, values, labelFormatter, renderChart])
 
   React.useEffect(() => {
     if (serverData && !isStatic) {
@@ -322,7 +322,7 @@ export function TimeSeries(props: TimeSeriesProps) {
 
   // @TODO: encapsulate this logic in a shared hook/component
   // @TODO: refactor the logic around the loading state, static and server data, and errors handling (data fetching and props mismatch)
-  if (((isStatic && loading) || (!isStatic && isLoading)) && !canvasRef.current) {
+  if (((isStatic && isLoadingStatic) || (!isStatic && isLoadingQuery)) && !canvasRef.current) {
     destroyChart()
     return <Loader styles={styles} />
   }
@@ -337,7 +337,7 @@ export function TimeSeries(props: TimeSeriesProps) {
         role={role || 'img'}
         aria-label={ariaLabel || defaultAriaLabel}
         style={{
-          opacity: isLoading || loading ? '0.3' : '1',
+          opacity: isLoadingQuery || isLoadingStatic ? '0.3' : '1',
           transition: 'opacity 0.2s ease-in-out'
         }}
         {...rest}

--- a/packages/react/time-series/src/TimeSeries.tsx
+++ b/packages/react/time-series/src/TimeSeries.tsx
@@ -105,6 +105,9 @@ export interface TimeSeriesProps extends ErrorFallbackProps, React.ComponentProp
 
     /** Interval in milliseconds for refetching the data */
     refetchInterval?: number
+
+    /** Whether to retry on errors. */
+    retry?: boolean
   }
   /** Format function for labels, must return an array with the new labels */
   labelFormatter?: (labels: string[]) => string[]
@@ -158,6 +161,7 @@ export function TimeSeries(props: TimeSeriesProps) {
       endpoint: PROPEL_GRAPHQL_API_ENDPOINT,
       fetchParams: {
         headers: {
+          'content-type': 'application/json',
           authorization: `Bearer ${query?.accessToken}`
         }
       }
@@ -178,14 +182,10 @@ export function TimeSeries(props: TimeSeriesProps) {
     },
     {
       refetchInterval: query?.refetchInterval,
+      retry: query?.retry,
       enabled: !isStatic
     }
   )
-
-  /*
-      const labels = metricData?.labels ?? []
-      const values = (metricData?.values ?? []).map((value) => (value == null ? null : Number(value)))
-   */
 
   const renderChart = React.useCallback(
     (data?: TimeSeriesData) => {
@@ -322,7 +322,7 @@ export function TimeSeries(props: TimeSeriesProps) {
 
   // @TODO: encapsulate this logic in a shared hook/component
   // @TODO: refactor the logic around the loading state, static and server data, and errors handling (data fetching and props mismatch)
-  if ((isLoading || loading || (serverData === undefined && !isStatic)) && !canvasRef.current) {
+  if (((isStatic && loading) || (!isStatic && isLoading)) && !canvasRef.current) {
     destroyChart()
     return <Loader styles={styles} />
   }

--- a/packages/react/time-series/src/__test__/TimeSeries.test.tsx
+++ b/packages/react/time-series/src/__test__/TimeSeries.test.tsx
@@ -53,4 +53,6 @@ describe('TimeSeries', () => {
     expect(chartLabels).toEqual(timeSeries.labels)
     expect(chartData).toEqual(timeSeries.values)
   })
+
+  // TODO: Add error tests.
 })

--- a/packages/react/time-series/src/__test__/TimeSeries.test.tsx
+++ b/packages/react/time-series/src/__test__/TimeSeries.test.tsx
@@ -51,8 +51,36 @@ describe('TimeSeries', () => {
     const chartLabels = chartInstance?.data.labels
 
     expect(chartLabels).toEqual(timeSeries.labels)
-    expect(chartData).toEqual(timeSeries.values)
+    expect(chartData).toEqual(timeSeries.values.map((value) => Number(value)))
   })
 
-  // TODO: Add error tests.
+  it('should show error fallback when query fails', async () => {
+    dom = render(
+      <TimeSeries
+        query={{
+          accessToken: 'test-token',
+          metric: 'should-fail',
+          timeRange: {
+            relative: RelativeTimeRange.LastNDays,
+            n: 30
+          },
+          granularity: TimeSeriesGranularity.Day,
+          retry: false
+        }}
+      />
+    )
+
+    await dom.findByText('Unable to connect')
+
+    await dom.findByText('Sorry we are not able to connect at this time due to a technical error.')
+  })
+
+  it('should show error fallback on props mismatch', async () => {
+    dom = render(<TimeSeries labels={['a', 'b', 'c']} />)
+
+    await dom.findByText('Unable to connect')
+
+    // TODO: this message suggests that the error is due to a network issue when it's not, maybe we should think about changing the message depending on the error
+    await dom.findByText('Sorry we are not able to connect at this time due to a technical error.')
+  })
 })

--- a/packages/react/time-series/src/__test__/mockData.ts
+++ b/packages/react/time-series/src/__test__/mockData.ts
@@ -1,4 +1,4 @@
 export const timeSeries = {
   labels: ['2023-07-01', '2023-07-02', '2023-07-03'],
-  values: [10, 20, 15]
+  values: ['10', '20', '15']
 }

--- a/packages/react/time-series/src/__test__/mswHandlers.ts
+++ b/packages/react/time-series/src/__test__/mswHandlers.ts
@@ -1,10 +1,23 @@
 import { graphql } from 'msw'
+import { mockTimeSeriesQuery } from './mockHandlers'
 import { server } from '@/testing/mocks/server'
 
 import { timeSeries } from './mockData'
 
 const handlers = [
-  graphql.query('TimeSeries', (req, res, ctx) => {
+  mockTimeSeriesQuery((req, res, ctx) => {
+    const { metricName } = req.variables.timeSeriesInput
+
+    if (metricName === 'should-fail') {
+      return res(
+        ctx.errors([
+          {
+            message: 'Something went wrong'
+          }
+        ])
+      )
+    }
+
     return res(
       ctx.data({
         timeSeries

--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["codegen.yml", "package.json", "src/**", "tsconfig.json"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**", "src/__test__/mockHandlers.ts"]
     },
     "lint": {
       "outputs": []

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "inputs": ["package.json", "src/**", "tsconfig.json"],
+      "inputs": ["codegen.yml", "package.json", "src/**", "tsconfig.json"],
       "outputs": ["dist/**"]
     },
     "lint": {

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,9 @@
     "dev": {
       "cache": false
     },
-    "test": {}
+    "test": {
+      "dependsOn": ["^build"]
+    }
   },
   "globalDependencies": ["tsconfig.json"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2584,6 +2584,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@graphql-codegen/typescript-msw@npm:^1.1.6":
+  version: 1.1.6
+  resolution: "@graphql-codegen/typescript-msw@npm:1.1.6::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-msw%2F-%2Ftypescript-msw-1.1.6.tgz"
+  dependencies:
+    "@graphql-codegen/plugin-helpers": ^2.7.2
+    "@graphql-codegen/visitor-plugin-common": 2.13.1
+    auto-bind: ~4.0.0
+    change-case-all: 1.0.14
+    tslib: ~2.4.0
+  peerDependencies:
+    graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+  checksum: 85f1b71c01ddf1a397d6ac63fc54a589b9fc98bf40be790b5636daf56faf6ce1462a9462ca265b984e2977f59d81251dc55db153c05f5a8d6941615a94cecd88
+  languageName: node
+  linkType: hard
+
 "@graphql-codegen/typescript-operations@npm:^4.0.1":
   version: 4.0.1
   resolution: "@graphql-codegen/typescript-operations@npm:4.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40graphql-codegen%2Ftypescript-operations%2F-%2Ftypescript-operations-4.0.1.tgz"
@@ -4097,6 +4112,7 @@ __metadata:
     "@graphql-codegen/add": ^4.0.0
     "@graphql-codegen/cli": ^4.0.1
     "@graphql-codegen/typescript": ^4.0.1
+    "@graphql-codegen/typescript-msw": ^1.1.6
     "@graphql-codegen/typescript-operations": ^4.0.1
     "@graphql-codegen/typescript-react-query": ^4.1.0
     "@tanstack/react-query": ^4.29.17

--- a/yarn.lock
+++ b/yarn.lock
@@ -3980,7 +3980,6 @@ __metadata:
     "@types/react-dom": latest
     "@types/testing-library__jest-dom": ^5.14.7
     graphql: ^16.0.1
-    graphql-request: ^6.1.0
     jest: ^27.5.1
     jest-environment-jsdom: ^27.5.1
     msw: ^1.2.2
@@ -4013,7 +4012,6 @@ __metadata:
     "@types/testing-library__jest-dom": ^5.14.7
     chart.js: ^4.1.2
     graphql: ^16.6.0
-    graphql-request: ^6.1.0
     jest: ^27.5.1
     jest-canvas-mock: ^2.5.2
     jest-environment-jsdom: ^27.5.1
@@ -4048,7 +4046,6 @@ __metadata:
     chart.js: ^4.2.1
     date-fns: ^2.29.3
     graphql: ^16.6.0
-    graphql-request: ^6.1.0
     jest: ^27.5.1
     jest-canvas-mock: ^2.5.2
     jest-environment-jsdom: ^27.5.1
@@ -4105,7 +4102,6 @@ __metadata:
     "@tanstack/react-query": ^4.29.17
     dotenv: ^16.0.3
     graphql: ^16.6.0
-    graphql-request: ^6.1.0
     react: ^18.2.0
     react-dom: ^18.2.0
     typescript: ^4.9.4
@@ -14167,7 +14163,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql-request@npm:^6.0.0, graphql-request@npm:^6.1.0":
+"graphql-request@npm:^6.0.0":
   version: 6.1.0
   resolution: "graphql-request@npm:6.1.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fgraphql-request%2F-%2Fgraphql-request-6.1.0.tgz"
   dependencies:


### PR DESCRIPTION
## Description

@felipecadavid I think we need to take a simpler approach to using react-query. The GraphQL code generator is already producing react-query hooks, so we should not be writing more code to wrap react-query or to use features like `refetchInterval`. And actually, we don't even need to depend on graphql-request, we can use `fetch`.

Let's please try to get a version of this working, with your React 16, 17 and 18 app changes. ~It's not yet working, and I'm not sure why.~ There's a lot of complicated hook logic in the components that should be simplified.

**UPDATE:** I got it working. Additionally, I noticed

- We were not using the GraphQL code generator's msw mocks. We should always try to use these, so I added them.
- Our logic for showing the loading state seems messy. We have to pairs of "is loading" values we need to check, depending on `isStatic`. So it becomes `(isStatic && loading) || (!isStatic && isLoading)`. It's not super clean. We should come back and simplify this.
- We lack error tests for TimeSeries and Leaderboard.
## Checklist

Before merging to main:

- [x] Tests
- [x] Manually tested in React apps
- [x] Release notes
- [x] Approved

## Release notes

```md
# Component changes

## Time Series

- Added the `refetchInterval` prop, which allows configuring the interval at which the Time Series component re-fetches data from the server. By default, re-fetching is disabled.
- Added the `retry` prop, which controls whether or not errors will be retried a default number of times. By default, errors are retried.
- Removed dependency on graphql-request.
- Export TimeSeriesProps.

## Leaderboard

- Added the `refetchInterval` prop, which allows configuring the interval at which the Time Series component re-fetches data from the server. By default, re-fetching is disabled.
- Added the `retry` prop, which controls whether or not errors will be retried a default number of times. By default, errors are retried.
- Removed dependency on graphql-request.
- Export LeaderboardProps and Styles.

## Counter

- Added the `refetchInterval` prop, which allows configuring the interval at which the Time Series component re-fetches data from the server. By default, re-fetching is disabled.
- Added the `retry` prop, which controls whether or not errors will be retried a default number of times. By default, errors are retried.
- Removed dependency on graphql-request.
- Export CounterProps and Styles.

# Packages changes

## GraphQL

- Removed dependency on graphql-request.

# App changes

## React sample apps.

- Added a test in every sample app for testing `refetchInterval`.

## Storybook

N/A
```
