### PR TITLE
Remove storybook connected controls

### DIFF
--- a/app/storybook/.yarnrc.yml
+++ b/app/storybook/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/app/storybook/src/stories/react/Counter.stories.tsx
+++ b/app/storybook/src/stories/react/Counter.stories.tsx
@@ -4,7 +4,14 @@ import { css } from '@emotion/css'
 import { Counter, RelativeTimeRange } from '@propeldata/react-counter'
 
 export default {
-  title: 'React/Counter'
+  title: 'React/Counter',
+  argTypes: {
+    query: {
+      table: {
+        disable: true
+      }
+    }
+  }
 }
 
 const UnstyledTemplate: Story = (args) => (
@@ -86,7 +93,7 @@ const CardTemplate: Story = (args) => (
   </div>
 )
 
-export const Connected = CardTemplate.bind({})
+export const Connected = CardTemplate.bind({ controls: 'disabled' })
 Connected.args = {
   query: {
     accessToken: '<PROPEL_ACCESS_TOKEN>',

--- a/app/storybook/src/stories/react/Leaderboard.stories.tsx
+++ b/app/storybook/src/stories/react/Leaderboard.stories.tsx
@@ -6,7 +6,14 @@ import { Sort } from '@propeldata/ui-kit-graphql'
 import { Leaderboard, RelativeTimeRange } from '@propeldata/react-leaderboard'
 
 export default {
-  title: 'React/Leaderboard'
+  title: 'React/Leaderboard',
+  argTypes: {
+    query: {
+      table: {
+        disable: true
+      }
+    }
+  }
 }
 
 const accessToken = '<ACCESS_TOKEN>'

--- a/app/storybook/src/stories/react/TimeSeries.stories.tsx
+++ b/app/storybook/src/stories/react/TimeSeries.stories.tsx
@@ -5,7 +5,14 @@ import { format } from 'date-fns'
 import { TimeSeries, RelativeTimeRange, TimeSeriesGranularity } from '@propeldata/react-time-series'
 
 export default {
-  title: 'React/TimeSeries'
+  title: 'React/TimeSeries',
+  argTypes: {
+    query: {
+      table: {
+        disable: true
+      }
+    }
+  }
 }
 
 const dataset = {

--- a/app/storybook/src/stories/react/examples/Dashboard.stories.tsx
+++ b/app/storybook/src/stories/react/examples/Dashboard.stories.tsx
@@ -19,7 +19,14 @@ export default {
         <Story />
       </S.Body>
     )
-  ]
+  ],
+  argTypes: {
+    query: {
+      table: {
+        disable: true
+      }
+    }
+  }
 }
 
 const queryBase = {


### PR DESCRIPTION
## Description of changes

This PR removes controls for `query` in storybook to avoid confusion.

## Checklist

Before merging to main:

- [ ] Release notes
- [ ] Approved

## Release notes

```md

## Storybook

- Removed `query` prop control for Counter, Timeseries and Leaderboard.
```
