### PR TITLE
Export CommonJS modules

### DIFF
--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -6,7 +6,7 @@
   "main": "dist/cjs/index.js",
   "module": "dist/mjs/index.module.js",
   "scripts": {
-    "build": "rm -rf dist && yarn graphql:build && tsc -p tsconfig.mjs.json && tsc -p tsconfig.cjs.json && ./fixup",
+    "build": "rm -rf dist && yarn graphql:build && tsc -p tsconfig.mjs.json && tsc -p tsconfig.cjs.json",
     "graphql:build": "rm -rf src/helpers/graphql/generated && yarn graphql:gen",
     "graphql:gen": "graphql-codegen --config src/helpers/graphql/codegen.yml && node src/helpers/graphql/script.cjs src/helpers/graphql/generated/index.ts",
     "test": "jest",

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -3,11 +3,10 @@
   "version": "0.2.0-rc.0",
   "license": "MIT",
   "source": "src/index.ts",
-  "main": "dist/index.js",
-  "module": "dist/index.module.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/cjs/index.js",
+  "module": "dist/mjs/index.module.js",
   "scripts": {
-    "build": "rm -rf dist && yarn graphql:build && tsc -p tsconfig.build.json",
+    "build": "rm -rf dist && yarn graphql:build && tsc -p tsconfig.mjs.json && tsc -p tsconfig.cjs.json && ./fixup",
     "graphql:build": "rm -rf src/helpers/graphql/generated && yarn graphql:gen",
     "graphql:gen": "graphql-codegen --config src/helpers/graphql/codegen.yml && node src/helpers/graphql/script.cjs src/helpers/graphql/generated/index.ts",
     "test": "jest",
@@ -57,5 +56,11 @@
     "graphql": "^16.6",
     "react": "^16.8 || ^17 || ^18",
     "react-dom": "^16.8 || ^17 || ^18"
+  },
+  "exports": {
+    ".": {
+      "import": "./dist/mjs/index.js",
+      "require": "./dist/cjs/index.js"
+    }
   }
 }

--- a/packages/ui-kit/tsconfig.build.json
+++ b/packages/ui-kit/tsconfig.build.json
@@ -1,9 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "src",
-    "outDir": "dist"
-  },
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["src/**/*.stories.*", "src/**/*.test.*"]
-}

--- a/packages/ui-kit/tsconfig.cjs.json
+++ b/packages/ui-kit/tsconfig.cjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist/cjs",
+    "module": "CommonJS"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/**/*.stories.*", "src/**/*.test.*"]
+}

--- a/packages/ui-kit/tsconfig.mjs.json
+++ b/packages/ui-kit/tsconfig.mjs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist/mjs",
+    "module": "ESNext"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/**/*.stories.*", "src/**/*.test.*"]
+}


### PR DESCRIPTION
## Description of changes

This PR exports the ui-kit as both CommonJS and ESM, the approach used is based on [this blogpost](https://www.sensedeep.com/blog/posts/2021/how-to-create-single-source-npm-module.html)

This will bundle two versions of the UI-Kit, one for CommonJS and one for ESM.

![image](https://github.com/propeldata/ui-kit/assets/84721399/31d6058a-230c-4a1b-8a80-c865dedebcf2)


## Checklist

Before merging to main:

- [x] ~Tests~
- [x] Manually tested in React apps
- [x] Release notes
- [ ] Approved

## Release notes

```md
## UI-Kit

- Export UI-Kit as CJS and ESM.
```
