### PR TITLE
fix(timeseries): fix date adapter side effect

### DIFF
--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
@@ -15,7 +15,7 @@ import {
 } from 'chart.js'
 import React from 'react'
 import { customCanvasBackgroundColor, PROPEL_GRAPHQL_API_ENDPOINT, useTimeSeriesQuery } from '../../helpers'
-import '../../helpers/chartJsAdapterDateFns'
+import * as chartJsAdapterDateFns from '../../helpers/chartJsAdapterDateFns'
 import { ChartPlugins, ChartStyles, defaultAriaLabel, defaultChartHeight, defaultStyles } from '../../themes'
 import { ErrorFallback } from '../ErrorFallback'
 import { Loader } from '../Loader'
@@ -54,6 +54,10 @@ let idCounter = 0
 // @TODO: refactor due to query and styles causing a re-render even if they are the same
 
 export const TimeSeriesComponent = (props: TimeSeriesProps) => {
+  React.useEffect(() => {
+    chartJsAdapterDateFns
+  }, [])
+
   const {
     variant = 'bar',
     styles,


### PR DESCRIPTION
## Description of changes

This PR fixes [the issue with missed Chart's date adapter](https://linear.app/propel/issue/PRO-2244/bug-broken-date-adapter-in-connected-timeseries).

### Connected TimeSeries before
![image](https://github.com/propeldata/ui-kit/assets/55801864/f88151cc-e42e-4f2b-87ee-2291d3908d5a)

### Connected TimeSeries after
<img width="1160" alt="image" src="https://github.com/propeldata/ui-kit/assets/55801864/bbcba87b-ddf2-4542-9918-27e5066475cd">

## Checklist

Before merging to main:

- [ ] Tests
- [x] Manually tested in React apps
- [ ] Release notes
- [ ] Approved

## Release notes

```md
# Component changes

## Time Series

- Fix missed Chart's date adapter.

