### PR TITLE
PRO-2259 Fix: remove MSW from bundle

### DIFF
--- a/packages/ui-kit/src/components/Counter/Counter.test.tsx
+++ b/packages/ui-kit/src/components/Counter/Counter.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react'
 import React from 'react'
-import { mockCounterQuery, RelativeTimeRange } from '../../helpers'
+import { mockCounterQuery, RelativeTimeRange } from '../../helpers/testing'
 import { Dom, setupTestHandlers } from '../../helpers/testing'
 import { Counter } from './Counter'
 

--- a/packages/ui-kit/src/components/Leaderboard/Leaderboard.test.tsx
+++ b/packages/ui-kit/src/components/Leaderboard/Leaderboard.test.tsx
@@ -1,8 +1,8 @@
 import { render, waitFor } from '@testing-library/react'
 import { Chart } from 'chart.js'
 import React from 'react'
-import { mockLeaderboardQuery, RelativeTimeRange } from '../../helpers'
-import { Dom, setupTestHandlers } from '../../helpers/testing'
+import { RelativeTimeRange } from '../../helpers'
+import { Dom, setupTestHandlers, mockLeaderboardQuery } from '../../helpers/testing'
 import { Leaderboard } from './Leaderboard'
 
 const mockData = {

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.test.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.test.tsx
@@ -1,8 +1,8 @@
 import { render } from '@testing-library/react'
 import { Chart } from 'chart.js'
 import React from 'react'
-import { mockTimeSeriesQuery, RelativeTimeRange, TimeSeriesGranularity } from '../../helpers'
-import { Dom, setupTestHandlers } from '../../helpers/testing'
+import { RelativeTimeRange, TimeSeriesGranularity } from '../../helpers'
+import { Dom, setupTestHandlers, mockTimeSeriesQuery } from '../../helpers/testing'
 import { TimeSeries } from '../index'
 
 const mockData = {

--- a/packages/ui-kit/src/helpers/graphql/codegen.yml
+++ b/packages/ui-kit/src/helpers/graphql/codegen.yml
@@ -8,9 +8,24 @@ generates:
     plugins:
       - add
       - typescript
-      - typescript-msw
       - typescript-operations
       - typescript-react-query
+    config:
+      # https://github.com/dotansimha/graphql-code-generator/issues/9046
+      content:
+        - // @ts-nocheck
+      fetcher: fetch
+
+  # Mocks
+
+  src/helpers/testing/generated/index.ts:
+    schema: src/helpers/graphql/public.graphql
+    documents:
+      - src/helpers/graphql/queries/**/*.graphql
+    plugins:
+      - add
+      - typescript
+      - typescript-msw
     config:
       # https://github.com/dotansimha/graphql-code-generator/issues/9046
       content:

--- a/packages/ui-kit/src/helpers/testing/index.ts
+++ b/packages/ui-kit/src/helpers/testing/index.ts
@@ -10,3 +10,4 @@ import { render } from '@testing-library/react'
 export type Dom = ReturnType<typeof render>
 
 export * from './mockServer'
+export * from './generated'

--- a/packages/ui-kit/tsconfig.cjs.json
+++ b/packages/ui-kit/tsconfig.cjs.json
@@ -6,5 +6,5 @@
     "module": "CommonJS"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["src/**/*.stories.*", "src/**/*.test.*"]
+  "exclude": ["src/**/*.stories.*", "src/**/*.test.*", "src/**/__test__/**/*", "src/**/testing/**/*"]
 }

--- a/packages/ui-kit/tsconfig.mjs.json
+++ b/packages/ui-kit/tsconfig.mjs.json
@@ -6,5 +6,5 @@
     "module": "ESNext"
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["src/**/*.stories.*", "src/**/*.test.*"]
+  "exclude": ["src/**/*.stories.*", "src/**/*.test.*", "src/**/__test__/**/*", "src/**/testing/**/*"]
 }


### PR DESCRIPTION
## Description of changes

This PR fixes a bug where MSW generated handlers where being added to the bundle, as MSW is a dev dependency it was causing apps without MSW to crash.

## Checklist

Before merging to main:

- [x] ~Tests~
- [x] Manually tested in React apps
- [x] Release notes
- [ ] Approved

## Release notes

```md
# Package changes

## GraphQL

- Removed msw handlers from generated files and set them into testing folder.
```
