### PR TITLE
Add `propelApiUrl` prop to set the api endpoint

### DIFF
--- a/packages/ui-kit/src/components/Counter/Counter.tsx
+++ b/packages/ui-kit/src/components/Counter/Counter.tsx
@@ -37,7 +37,7 @@ const CounterComponent = (props: CounterProps) => {
     data: fetchedValue
   } = useCounterQuery(
     {
-      endpoint: PROPEL_GRAPHQL_API_ENDPOINT,
+      endpoint: query?.propelApiUrl ?? PROPEL_GRAPHQL_API_ENDPOINT,
       fetchParams: {
         headers: {
           'content-type': 'application/json',

--- a/packages/ui-kit/src/components/Counter/Counter.types.ts
+++ b/packages/ui-kit/src/components/Counter/Counter.types.ts
@@ -29,6 +29,8 @@ export interface CounterProps extends React.ComponentProps<'span'> {
     refetchInterval?: number
     /** Whether to retry on errors. */
     retry?: boolean
+    /** The Propel's API URL, defaults to the production API */
+    propelApiUrl?: string
   }
   /** When true, shows a skeleton loader */
   loading?: boolean

--- a/packages/ui-kit/src/components/Counter/Counter.types.ts
+++ b/packages/ui-kit/src/components/Counter/Counter.types.ts
@@ -29,7 +29,7 @@ export interface CounterProps extends React.ComponentProps<'span'> {
     refetchInterval?: number
     /** Whether to retry on errors. */
     retry?: boolean
-    /** The Propel's API URL, defaults to the production API */
+    /** This prop allows you to override the URL for Propel's GraphQL API. You shouldn't need to set this unless you are testing. */
     propelApiUrl?: string
   }
   /** When true, shows a skeleton loader */

--- a/packages/ui-kit/src/components/Leaderboard/Leaderboard.tsx
+++ b/packages/ui-kit/src/components/Leaderboard/Leaderboard.tsx
@@ -146,7 +146,7 @@ const LeaderboardComponent = (props: LeaderboardProps) => {
     data: fetchedData
   } = useLeaderboardQuery(
     {
-      endpoint: PROPEL_GRAPHQL_API_ENDPOINT,
+      endpoint: query?.propelApiUrl ?? PROPEL_GRAPHQL_API_ENDPOINT,
       fetchParams: {
         headers: {
           'content-type': 'application/json',

--- a/packages/ui-kit/src/components/Leaderboard/Leaderboard.types.ts
+++ b/packages/ui-kit/src/components/Leaderboard/Leaderboard.types.ts
@@ -63,5 +63,7 @@ export interface LeaderboardProps extends ErrorFallbackProps, React.ComponentPro
 
     /** Whether to retry on errors. */
     retry?: boolean
+    /** The Propel's API URL, defaults to the production API */
+    propelApiUrl?: string
   }
 }

--- a/packages/ui-kit/src/components/Leaderboard/Leaderboard.types.ts
+++ b/packages/ui-kit/src/components/Leaderboard/Leaderboard.types.ts
@@ -63,7 +63,7 @@ export interface LeaderboardProps extends ErrorFallbackProps, React.ComponentPro
 
     /** Whether to retry on errors. */
     retry?: boolean
-    /** The Propel's API URL, defaults to the production API */
+    /** This prop allows you to override the URL for Propel's GraphQL API. You shouldn't need to set this unless you are testing. */
     propelApiUrl?: string
   }
 }

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
@@ -107,7 +107,7 @@ export const TimeSeriesComponent = (props: TimeSeriesProps) => {
     data: serverData
   } = useTimeSeriesQuery(
     {
-      endpoint: PROPEL_GRAPHQL_API_ENDPOINT,
+      endpoint: query?.propelApiUrl ?? PROPEL_GRAPHQL_API_ENDPOINT,
       fetchParams: {
         headers: {
           'content-type': 'application/json',

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.types.ts
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.types.ts
@@ -65,6 +65,9 @@ export interface TimeSeriesProps extends ErrorFallbackProps, React.ComponentProp
 
     /** Whether to retry on errors. */
     retry?: boolean
+
+    /** The Propel's API URL, defaults to the production API */
+    propelApiUrl?: string
   }
   /** Format function for labels, must return an array with the new labels */
   labelFormatter?: (labels: string[]) => string[]

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.types.ts
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.types.ts
@@ -66,7 +66,7 @@ export interface TimeSeriesProps extends ErrorFallbackProps, React.ComponentProp
     /** Whether to retry on errors. */
     retry?: boolean
 
-    /** The Propel's API URL, defaults to the production API */
+    /** This prop allows you to override the URL for Propel's GraphQL API. You shouldn't need to set this unless you are testing. */
     propelApiUrl?: string
   }
   /** Format function for labels, must return an array with the new labels */


### PR DESCRIPTION
## Description of changes

This PR adds the `propelApiUrl` prop to allow overriding the graphql api endpoint

## Checklist

Before merging to main:

- [ ] Tests
- [x] Manually tested in React apps
- [x] Release notes
- [x] Approved

## Release notes

```md
# Component changes

## Time Series

- Added `propelApiUrl` prop.

## Leaderboard

- Added `propelApiUrl` prop.

## Counter

- Added `propelApiUrl` prop.
```
