### PR TITLE
Format TimeSeries tooltip according to granularity

### DIFF
--- a/.pnp.loader.mjs
+++ b/.pnp.loader.mjs
@@ -1471,7 +1471,7 @@ async function load$1(urlString, context, nextLoad) {
   }
   return {
     format,
-    source: format === `commonjs` ? void 0 : await fs.promises.readFile(filePath, `utf8`),
+    source: await fs.promises.readFile(filePath, `utf8`),
     shortCircuit: true
   };
 }

--- a/packages/ui-kit/package.json
+++ b/packages/ui-kit/package.json
@@ -43,6 +43,7 @@
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^27.5.1",
+    "@types/luxon": "^3.3.2",
     "@types/react": "latest",
     "@types/react-dom": "latest",
     "@types/testing-library__jest-dom": "^5.14.7",

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
@@ -30,6 +30,7 @@ import {
   formatLabels,
   getDefaultGranularity,
   getScales,
+  tooltipTitleCallback,
   updateChartConfig,
   updateChartStyles,
   useSetupDefaultStyles
@@ -158,6 +159,11 @@ export const TimeSeriesComponent = (props: TimeSeriesProps) => {
       const customPlugins: ChartPlugins = {
         customCanvasBackgroundColor: {
           color: styles?.canvas?.backgroundColor
+        },
+        tooltip: {
+          callbacks: {
+            title: (context: { label: string }[]) => tooltipTitleCallback(context, granularity)
+          }
         }
       }
 

--- a/packages/ui-kit/src/components/TimeSeries/utils.test.ts
+++ b/packages/ui-kit/src/components/TimeSeries/utils.test.ts
@@ -1,6 +1,6 @@
 import { TimeSeriesGranularity } from '../../testing'
 
-import { getLabelsBasedGranularity } from './utils'
+import { getLabelsBasedGranularity, tooltipTitleCallback } from './utils'
 
 describe('TimeSeries/utils', () => {
   describe('getLabelsBasedGranularity', () => {
@@ -128,6 +128,47 @@ describe('TimeSeries/utils', () => {
       const result = getLabelsBasedGranularity(labels)
 
       expect(result).toEqual(TimeSeriesGranularity.Year)
+    })
+  })
+
+  describe('tooltipTitleCallback', () => {
+    it('should return label unformatted for a granularity lower than DAY', () => {
+      const label = 'Aug 1, 2023, 12:00:00 AM'
+
+      let result: string
+
+      result = tooltipTitleCallback([{ label }], TimeSeriesGranularity.Minute)
+      expect(result).toBe(label)
+
+      result = tooltipTitleCallback([{ label }], TimeSeriesGranularity.FiveMinutes)
+      expect(result).toBe(label)
+
+      result = tooltipTitleCallback([{ label }], TimeSeriesGranularity.TenMinutes)
+      expect(result).toBe(label)
+
+      result = tooltipTitleCallback([{ label }], TimeSeriesGranularity.FifteenMinutes)
+      expect(result).toBe(label)
+
+      result = tooltipTitleCallback([{ label }], TimeSeriesGranularity.Hour)
+      expect(result).toBe(label)
+    })
+
+    it('should format correctly for DAY granularity', () => {
+      const result = tooltipTitleCallback([{ label: 'Aug 1, 2023, 12:00:00 AM' }], TimeSeriesGranularity.Day)
+
+      expect(result).toBe('Aug 1, 2023')
+    })
+
+    it('should format correctly for MONTH granularity', () => {
+      const result = tooltipTitleCallback([{ label: 'Aug 1, 2023, 12:00:00 AM' }], TimeSeriesGranularity.Month)
+
+      expect(result).toBe('August, 2023')
+    })
+
+    it('should format correctly for YEAR granularity', () => {
+      const result = tooltipTitleCallback([{ label: 'Aug 1, 2023, 12:00:00 AM' }], TimeSeriesGranularity.Month)
+
+      expect(result).toBe('August, 2023')
     })
   })
 })

--- a/packages/ui-kit/src/components/TimeSeries/utils.ts
+++ b/packages/ui-kit/src/components/TimeSeries/utils.ts
@@ -10,6 +10,7 @@ import {
   TextAlign,
   TimeUnit
 } from 'chart.js'
+import { DateTime } from 'luxon'
 import type { DeepPartial } from 'chart.js/dist/types/utils'
 import React from 'react'
 import { Maybe, RelativeTimeRange, TimeRangeInput, TimeSeriesGranularity } from '../../helpers'
@@ -372,4 +373,16 @@ export function getScales(options: GetScalesOptions) {
   }
 
   return logarithmicScales
+}
+
+export function tooltipTitleCallback(context: { label: string }[], granularity: TimeSeriesGranularity) {
+  const title = context[0].label
+  const date = new Date(title)
+
+  return {
+    [TimeSeriesGranularity.Day]: DateTime.fromJSDate(date).toFormat('LLL d, yyyy'),
+    [TimeSeriesGranularity.Week]: DateTime.fromJSDate(date).toFormat('LLL d, yyyy'),
+    [TimeSeriesGranularity.Month]: DateTime.fromJSDate(date).toFormat('LLLL, yyyy'),
+    [TimeSeriesGranularity.Year]: DateTime.fromJSDate(date).toFormat('yyyy')
+  }[granularity] ?? title
 }

--- a/packages/ui-kit/src/themes/default.types.ts
+++ b/packages/ui-kit/src/themes/default.types.ts
@@ -9,7 +9,7 @@ export type ChartPaddingOptions =
 
 export type ChartPlugins = {
   [pluginName: string]: {
-    [optionName: string]: string | undefined
+    [optionName: string]: string | undefined | unknown
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4132,6 +4132,7 @@ __metadata:
     "@testing-library/react": ^14.0.0
     "@testing-library/user-event": ^14.4.3
     "@types/jest": ^27.5.1
+    "@types/luxon": ^3.3.2
     "@types/react": latest
     "@types/react-dom": latest
     "@types/testing-library__jest-dom": ^5.14.7
@@ -6410,6 +6411,13 @@ __metadata:
   version: 4.14.198
   resolution: "@types/lodash@npm:4.14.198::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Flodash%2F-%2Flodash-4.14.198.tgz"
   checksum: b290e4480707151bcec738bca40527915defe52a0d8e26c83685c674163a265e1a88cb2ee56b0fb587a89819d0cd5df86ada836aec3e9c2e4bf516e7d348d524
+  languageName: node
+  linkType: hard
+
+"@types/luxon@npm:^3.3.2":
+  version: 3.3.2
+  resolution: "@types/luxon@npm:3.3.2::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40types%2Fluxon%2F-%2Fluxon-3.3.2.tgz"
+  checksum: b9111132720eae0269538872a5a496b29587ecfc8edc3b0ff7d269aa93a5ff00a131b23d1e9d1f12ec39f2c779ad21bd8d9f90b122c85a182771aabde7f676b8
   languageName: node
   linkType: hard
 
@@ -24718,11 +24726,11 @@ __metadata:
 
 "typescript@patch:typescript@^4.6.4 || ^5.0.0#~builtin<compat/typescript>":
   version: 5.2.2
-  resolution: "typescript@patch:typescript@npm%3A5.2.2%3A%3A__archiveUrl=https%253A%252F%252Fregistry.npmjs.org%252Ftypescript%252F-%252Ftypescript-5.2.2.tgz#~builtin<compat/typescript>::version=5.2.2&hash=f3b441"
+  resolution: "typescript@patch:typescript@npm%3A5.2.2%3A%3A__archiveUrl=https%253A%252F%252Fregistry.npmjs.org%252Ftypescript%252F-%252Ftypescript-5.2.2.tgz#~builtin<compat/typescript>::version=5.2.2&hash=5da071"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 0f4da2f15e6f1245e49db15801dbee52f2bbfb267e1c39225afdab5afee1a72839cd86000e65ee9d7e4dfaff12239d28beaf5ee431357fcced15fb08583d72ca
+  checksum: 07106822b4305de3f22835cbba949a2b35451cad50888759b6818421290ff95d522b38ef7919e70fb381c5fe9c1c643d7dea22c8b31652a717ddbd57b7f4d554
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description of changes

This PR allows tooltip formatting according to granularity this way:

Granularity: DAY

Today we show: Aug 1, 2023, 12:00:00 AM

Desired value: Aug 1, 2023

Granularity: MONTH

Today we show: Aug 1, 2023, 12:00:00 AM

Desired value: August, 2023

Granularity: YEAR

Today we show: Jan 1, 2023, 12:00:00 AM

Desired value: 2023

For any granularity smaller than a day it makes sense to show the full time stamp

![image](https://github.com/propeldata/ui-kit/assets/84721399/d1094118-90ab-423b-90af-cce830308137)

## Checklist

Before merging to main:

- [x] Tests
- [x] Manually tested in React apps
- [x] Release notes
- [x] Approved

## Release notes

```md
# Component changes

## Time Series

- Format tooltip label based on granularity.
```
