### PR TITLE
fix(ui-kit): export common types

### DIFF
--- a/packages/ui-kit/src/index.ts
+++ b/packages/ui-kit/src/index.ts
@@ -1,2 +1,3 @@
 export * from './components'
 export * from './helpers'
+export * from './themes'


### PR DESCRIPTION
## Description of changes

This PR solves [Export more types from UI Kit](https://linear.app/propel/issue/PRO-2153/export-more-types-from-ui-kit)

## Checklist

Before merging to main:

- [x] Tests
- [x] Manually tested in React apps
- [x] Release notes
- [x] Approved

## Release notes

```md
# Package changes

## UI-kit

- Export Common types
```
