### PR TITLE
chore(ui-kit): remove propeller prop

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -47453,6 +47453,7 @@ function reportRequiredFilesToWatchMode(files) {
 }
 
 function applyPatch(pnpapi, opts) {
+  const defaultCache = {};
   let enableNativeHooks = true;
   process.versions.pnp = String(pnpapi.VERSIONS.std);
   const moduleExports = require$$0__default.default;
@@ -47472,13 +47473,62 @@ function applyPatch(pnpapi, opts) {
   }
   const originalModuleLoad = require$$0.Module._load;
   require$$0.Module._load = function(request, parent, isMain) {
-    if (request === `pnpapi`) {
-      const parentApiPath = opts.manager.getApiPathFromParent(parent);
-      if (parentApiPath) {
-        return opts.manager.getApiEntry(parentApiPath, true).instance;
+    if (!enableNativeHooks)
+      return originalModuleLoad.call(require$$0.Module, request, parent, isMain);
+    if (isBuiltinModule(request)) {
+      try {
+        enableNativeHooks = false;
+        return originalModuleLoad.call(require$$0.Module, request, parent, isMain);
+      } finally {
+        enableNativeHooks = true;
       }
     }
-    return originalModuleLoad.call(require$$0.Module, request, parent, isMain);
+    const parentApiPath = opts.manager.getApiPathFromParent(parent);
+    const parentApi = parentApiPath !== null ? opts.manager.getApiEntry(parentApiPath, true).instance : null;
+    if (parentApi === null)
+      return originalModuleLoad(request, parent, isMain);
+    if (request === `pnpapi`)
+      return parentApi;
+    const modulePath = require$$0.Module._resolveFilename(request, parent, isMain);
+    const isOwnedByRuntime = parentApi !== null ? parentApi.findPackageLocator(modulePath) !== null : false;
+    const moduleApiPath = isOwnedByRuntime ? parentApiPath : opts.manager.findApiPathFor(npath.dirname(modulePath));
+    const entry = moduleApiPath !== null ? opts.manager.getApiEntry(moduleApiPath) : { instance: null, cache: defaultCache };
+    const cacheEntry = entry.cache[modulePath];
+    if (cacheEntry) {
+      if (cacheEntry.loaded === false && cacheEntry.isLoading !== true) {
+        try {
+          cacheEntry.isLoading = true;
+          if (isMain) {
+            process.mainModule = cacheEntry;
+            cacheEntry.id = `.`;
+          }
+          cacheEntry.load(modulePath);
+        } finally {
+          cacheEntry.isLoading = false;
+        }
+      }
+      return cacheEntry.exports;
+    }
+    const module = new require$$0.Module(modulePath, parent != null ? parent : void 0);
+    module.pnpApiPath = moduleApiPath;
+    reportRequiredFilesToWatchMode([modulePath]);
+    entry.cache[modulePath] = module;
+    if (isMain) {
+      process.mainModule = module;
+      module.id = `.`;
+    }
+    let hasThrown = true;
+    try {
+      module.isLoading = true;
+      module.load(modulePath);
+      hasThrown = false;
+    } finally {
+      module.isLoading = false;
+      if (hasThrown) {
+        delete require$$0.Module._cache[modulePath];
+      }
+    }
+    return module.exports;
   };
   function getIssuerSpecsFromPaths(paths) {
     return paths.map((path) => ({
@@ -47546,7 +47596,7 @@ function applyPatch(pnpapi, opts) {
       const parentDirectory = (parent == null ? void 0 : parent.filename) != null ? npath.dirname(parent.filename) : null;
       const absoluteRequest = npath.isAbsolute(request) ? request : parentDirectory !== null ? npath.resolve(parentDirectory, request) : null;
       if (absoluteRequest !== null) {
-        const apiPath = parent && parentDirectory === npath.dirname(absoluteRequest) ? opts.manager.getApiPathFromParent(parent) : opts.manager.findApiPathFor(absoluteRequest);
+        const apiPath = parentDirectory === npath.dirname(absoluteRequest) && (parent == null ? void 0 : parent.pnpApiPath) ? parent.pnpApiPath : opts.manager.findApiPathFor(absoluteRequest);
         if (apiPath !== null) {
           issuerSpecs.unshift({
             apiPath,
@@ -49267,6 +49317,7 @@ function makeManager(pnpapi, opts) {
   const initialApiStats = opts.fakeFs.statSync(npath.toPortablePath(initialApiPath));
   const apiMetadata = /* @__PURE__ */ new Map([
     [initialApiPath, {
+      cache: require$$0.Module._cache,
       instance: pnpapi,
       stats: initialApiStats,
       lastRefreshCheck: Date.now()
@@ -49298,6 +49349,7 @@ function makeManager(pnpapi, opts) {
       }
     } else {
       apiMetadata.set(pnpApiPath, apiEntry = {
+        cache: {},
         instance: loadApiInstance(pnpApiPath),
         stats: opts.fakeFs.statSync(pnpApiPath),
         lastRefreshCheck: Date.now()
@@ -49367,16 +49419,19 @@ ${controlSegment}
     } while (curr !== PortablePath.root);
     return addToCacheAndReturn(start, curr, null);
   }
-  const moduleToApiPathCache = /* @__PURE__ */ new WeakMap();
   function getApiPathFromParent(parent) {
     if (parent == null)
       return initialApiPath;
-    let apiPath = moduleToApiPathCache.get(parent);
-    if (typeof apiPath !== `undefined`)
-      return apiPath;
-    apiPath = parent.filename ? findApiPathFor(parent.filename) : null;
-    moduleToApiPathCache.set(parent, apiPath);
-    return apiPath;
+    if (typeof parent.pnpApiPath === `undefined`) {
+      if (parent.filename !== null) {
+        return parent.pnpApiPath = findApiPathFor(parent.filename);
+      } else {
+        return initialApiPath;
+      }
+    }
+    if (parent.pnpApiPath !== null)
+      return parent.pnpApiPath;
+    return null;
   }
   return {
     getApiPathFromParent,

--- a/packages/ui-kit/src/components/Counter/Counter.tsx
+++ b/packages/ui-kit/src/components/Counter/Counter.tsx
@@ -55,8 +55,7 @@ export const CounterComponent = (props: CounterProps) => {
           start: query?.timeRange?.start ?? null,
           stop: query?.timeRange?.stop ?? null
         },
-        filters: query?.filters ?? [],
-        propeller: query?.propeller
+        filters: query?.filters ?? []
       }
     },
     {

--- a/packages/ui-kit/src/components/Counter/Counter.types.ts
+++ b/packages/ui-kit/src/components/Counter/Counter.types.ts
@@ -1,4 +1,4 @@
-import { FilterInput, Propeller, TimeRangeInput } from '../../helpers'
+import { FilterInput, TimeRangeInput } from '../../helpers'
 import type { ChartStyles } from '../../themes'
 
 export type CounterQueryProps = {
@@ -10,8 +10,6 @@ export type CounterQueryProps = {
   metric?: string
   /** Filters that the chart will respond to */
   filters?: FilterInput[]
-  /** Propeller that the chart will respond to */
-  propeller?: Propeller
   /** Interval in milliseconds for refetching the data */
   refetchInterval?: number
   /** Whether to retry on errors. */

--- a/packages/ui-kit/src/components/Leaderboard/Leaderboard.tsx
+++ b/packages/ui-kit/src/components/Leaderboard/Leaderboard.tsx
@@ -166,7 +166,6 @@ export const LeaderboardComponent = ({
       leaderboardInput: {
         metricName: query?.metric,
         filters: query?.filters,
-        propeller: query?.propeller,
         sort: query?.sort,
         rowLimit: query?.rowLimit ?? 100,
         dimensions: query?.dimensions,

--- a/packages/ui-kit/src/components/Leaderboard/Leaderboard.types.ts
+++ b/packages/ui-kit/src/components/Leaderboard/Leaderboard.types.ts
@@ -1,4 +1,4 @@
-import { DimensionInput, FilterInput, Propeller, Sort, TimeRangeInput } from '../../helpers'
+import { DimensionInput, FilterInput, Sort, TimeRangeInput } from '../../helpers'
 import { ChartStyles } from '../../themes'
 import type { ErrorFallbackProps } from '../ErrorFallback'
 
@@ -26,9 +26,6 @@ export type LeaderboardQueryProps = {
 
   /** Filters that the chart will respond to */
   filters?: FilterInput[]
-
-  /** Propeller that the chart will respond to */
-  propeller?: Propeller
 
   /** The number of rows to be returned. It can be a number between 1 and 1,000 */
   rowLimit?: number

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
@@ -133,8 +133,7 @@ export const TimeSeriesComponent: React.FC<TimeSeriesProps> = ({
           stop: query?.timeRange?.stop ?? null
         },
         granularity,
-        filters: query?.filters,
-        propeller: query?.propeller
+        filters: query?.filters
       }
     },
     {

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.types.ts
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.types.ts
@@ -1,6 +1,6 @@
 import type { ScaleOptionsByType } from 'chart.js'
 import { DeepPartial } from 'chart.js/dist/types/utils'
-import { FilterInput, Propeller, TimeRangeInput, TimeSeriesGranularity } from '../../helpers'
+import { FilterInput, TimeRangeInput, TimeSeriesGranularity } from '../../helpers'
 import { ChartStyles } from '../../themes'
 import { ErrorFallbackProps } from '../ErrorFallback'
 
@@ -28,9 +28,6 @@ export type TimeSeriesQueryProps = {
 
   /** Filters that the chart will respond to */
   filters?: FilterInput[]
-
-  /** Propeller that the chart will respond to (see <a href="https://studio.apollographql.com/graph/Propel-API/schema/reference/enums/Propeller?variant=production" target="_blank">Propeller</a>) */
-  propeller?: Propeller
 
   /** Timestamp format that the chart will respond to */
   timestampFormat?: string


### PR DESCRIPTION
## Description of changes

This PR solves [Remove Propeller from CounterQueryProps, LeaderboardQueryProps, and TimeSeriesQueryProps](https://linear.app/propel/issue/PRO-2400/remove-propeller-from-counterqueryprops-leaderboardqueryprops-and)

## Checklist

Before merging to main:

- [x] Tests
- [x] Manually tested in React apps
- [x] Release notes
- [x] Approved

## Release notes

```md
# Component changes

## Time Series

- Removed `propeller` prop from the `query` props.

## Leaderboard

- Removed `propeller` prop from the `query` props.

## Counter

- Removed `propeller` prop from the `query` props.
```
