### PR TITLE
chore(ui-kit): extend Chart.js register

### DIFF
--- a/.changeset/young-kings-tease.md
+++ b/.changeset/young-kings-tease.md
@@ -1,0 +1,5 @@
+---
+'@propeldata/ui-kit': patch
+---
+
+Unlock `Title`, `SubTitle`, `Legend` settings of Chart.js

--- a/packages/ui-kit/src/components/Leaderboard/Leaderboard.tsx
+++ b/packages/ui-kit/src/components/Leaderboard/Leaderboard.tsx
@@ -134,6 +134,9 @@ export const LeaderboardComponent = React.forwardRef<HTMLDivElement, Leaderboard
           customCanvasBackgroundColor: {
             color: card ? theme?.bgPrimary : 'transparent'
           },
+          legend: {
+            display: false
+          },
           customLeaderboardChartLabelsPlugin
         }
 

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
@@ -132,6 +132,9 @@ export const TimeSeriesComponent = React.forwardRef<HTMLDivElement, TimeSeriesPr
           customCanvasBackgroundColor: {
             color: card ? theme?.bgPrimary : 'transparent'
           },
+          legend: {
+            display: false
+          },
           tooltip: {
             callbacks: {
               title: (context: { label: string }[]) => tooltipTitleCallback(context, granularity)

--- a/packages/ui-kit/src/helpers/chartUtils/chartUtils.ts
+++ b/packages/ui-kit/src/helpers/chartUtils/chartUtils.ts
@@ -12,7 +12,10 @@ import {
   TimeSeriesScale,
   Tooltip,
   Filler,
-  ChartConfiguration
+  ChartConfiguration,
+  Title,
+  SubTitle,
+  Legend
 } from 'chart.js'
 import type { ThemeTokenProps } from '../../themes'
 
@@ -38,6 +41,9 @@ export const initChartJs = () => {
     LogarithmicScale,
     Tooltip,
     Colors,
+    Title,
+    SubTitle,
+    Legend,
     PointElement,
     BarElement,
     LineElement,


### PR DESCRIPTION
## Description of changes

This PR extends Chart.js register with `Title`, `SubTitle`, and `Legend`.

![image](https://github.com/propeldata/ui-kit/assets/55801864/49b38931-a9dd-4bcc-9030-27d58711c63d)

## Checklist

Before merging to main:

- [ ] Tests
- [x] Manually tested in React apps
- [x] Changesets
- [x] Approved
