### PR TITLE
Hide non-released features from storybook

### DIFF
--- a/app/storybook/.storybook/manager.ts
+++ b/app/storybook/.storybook/manager.ts
@@ -1,12 +1,27 @@
 import { addons } from '@storybook/manager-api'
 import { defaultTheme } from './defaultTheme'
 
+const env = process.env.NODE_ENV
+const devOnly = [
+  'Components/PieChart',
+  'Hooks/useTopValues',
+  'Hooks/useDataGrid',
+  'API/DataGridQueryProps',
+  'API/PieChartQueryProps',
+  'API/TopValuesQueryProps'
+]
+
 addons.setConfig({
   theme: defaultTheme,
   sidebar: {
     filters: {
       patterns: (item) => {
         return !item.tags?.includes('pattern')
+      },
+      devOnly: (item) => {
+        return (
+          env !== 'production' || !devOnly.map((element) => element.toLowerCase()).includes(item.title.toLowerCase())
+        )
       }
     }
   }


### PR DESCRIPTION
## Description of changes

This PR creates a setup to easily hide non-released features from storybook, we just need to add the story's title to the `devOnly` array in the `manager.ts` file, this results more useful than the `pattern` tag as we can add/remove hidden stories without having to go to each file and we will still be able to view stories in development.

```ts
const devOnly = [
  'Components/PieChart',
  'Hooks/useTopValues',
  'Hooks/useDataGrid',
  'API/DataGridQueryProps',
  'API/PieChartQueryProps',
  'API/TopValuesQueryProps'
]
```

I suggest we follow this line for now:

- When we create a story for a feature we add the title to the `devOnly` array
- Before releasing we clear this array in the `Version Packages` PR (hopefully we could do this automatically somehow)

## Checklist

Before merging to main:

- [ ] Tests
- [ ] Manually tested in React apps
- [ ] Changesets
- [x] Approved
