### PR TITLE
Import using relative paths

### DIFF
--- a/.changeset/odd-dragons-peel.md
+++ b/.changeset/odd-dragons-peel.md
@@ -1,0 +1,5 @@
+---
+'@propeldata/ui-kit': patch
+---
+
+Fixed type exports

--- a/.changeset/odd-dragons-peel.md
+++ b/.changeset/odd-dragons-peel.md
@@ -2,4 +2,4 @@
 '@propeldata/ui-kit': patch
 ---
 
-Fixed type exports
+Fixed component and type exports

--- a/packages/ui-kit/src/components/DataGrid/DataGrid.types.ts
+++ b/packages/ui-kit/src/components/DataGrid/DataGrid.types.ts
@@ -1,5 +1,5 @@
-import type { QueryProps } from 'src/components/shared.types'
-import type { DataPoolInput, Sort } from 'src/helpers'
+import type { QueryProps } from '../../components/shared.types'
+import type { DataPoolInput, Sort } from '../../helpers'
 
 export interface DataGridQueryProps extends Omit<QueryProps, 'metric'> {
   /** The columns to retrieve. */

--- a/packages/ui-kit/src/components/FilterProvider/FilterProvider.tsx
+++ b/packages/ui-kit/src/components/FilterProvider/FilterProvider.tsx
@@ -1,6 +1,6 @@
 import React, { createContext, useState } from 'react'
 
-import { FilterInput } from 'src/helpers'
+import { FilterInput } from '../../helpers'
 
 interface FilterInputWithId extends FilterInput {
   id: symbol

--- a/packages/ui-kit/src/components/PieChart/PieChart.types.ts
+++ b/packages/ui-kit/src/components/PieChart/PieChart.types.ts
@@ -1,5 +1,5 @@
 import type { ChartConfiguration } from 'chart.js'
-import { DimensionInput, Sort } from 'src/helpers'
+import { DimensionInput, Sort } from '../../helpers'
 import { ErrorFallbackProps } from '../ErrorFallback'
 import { DataComponentProps, QueryProps } from '../shared.types'
 

--- a/packages/ui-kit/src/components/RecordsById/RecordsById.types.ts
+++ b/packages/ui-kit/src/components/RecordsById/RecordsById.types.ts
@@ -1,5 +1,5 @@
-import type { QueryProps } from 'src/components/shared.types'
-import { DataPoolInput } from 'src/helpers'
+import type { QueryProps } from '../../components/shared.types'
+import { DataPoolInput } from '../../helpers'
 
 export interface RecordsByIdQueryProps extends Omit<QueryProps, 'timeZone' | 'timeRange' | 'metric' | 'filters'> {
   /** The Data Pool to be queried. A Data Pool ID or unique name can be provided. */

--- a/packages/ui-kit/src/components/TopValues/TopValues.types.ts
+++ b/packages/ui-kit/src/components/TopValues/TopValues.types.ts
@@ -1,5 +1,5 @@
-import type { QueryProps } from 'src/components/shared.types'
-import type { DataPoolInput } from 'src/helpers'
+import type { QueryProps } from '../../components/shared.types'
+import type { DataPoolInput } from '../../helpers'
 
 export interface TopValuesQueryProps extends Omit<QueryProps, 'filters'> {
   /** The column to fetch the unique values from */

--- a/packages/ui-kit/src/components/shared.types.ts
+++ b/packages/ui-kit/src/components/shared.types.ts
@@ -1,4 +1,4 @@
-import { FilterInput, MetricInput, TimeRangeInput } from 'src/helpers'
+import { FilterInput, MetricInput, TimeRangeInput } from '../helpers'
 import type { ErrorFallbackProps } from './ErrorFallback'
 import type { LoaderProps } from './Loader'
 

--- a/packages/ui-kit/src/hooks/useTopValues/useTopValues.test.tsx
+++ b/packages/ui-kit/src/hooks/useTopValues/useTopValues.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '../../helpers'
 import { Dom, mockTopValuesQuery, RelativeTimeRange, setupTestHandlers } from '../../testing'
 import { useTopValues } from './useTopValues'
-import { TopValuesQueryProps } from 'src/components/TopValues/TopValues.types'
+import { TopValuesQueryProps } from '../../components/TopValues/TopValues.types'
 
 const mockData = {
   values: ['a', 'b', 'c', 'd']


### PR DESCRIPTION
## Description of changes

This PR fixes imports to use relative paths instead of `src/` as this is breaking the exported types

## Checklist

Before merging to main:

- [x] ~Tests~
- [x] Manually tested in React apps
- [x] Changesets
- [ ] Approved
