### PR TITLE
Not pass timeRange to query when not provided

### DIFF
--- a/packages/ui-kit/src/helpers/graphql/public.graphql
+++ b/packages/ui-kit/src/helpers/graphql/public.graphql
@@ -717,6 +717,10 @@ enum DataSourceType {
   """
   Redshift
   """
+  Indicates a Kafka Data Source.
+  """
+  KAFKA
+  """
   Indicates an Http Data Source.
   """
   Http
@@ -724,10 +728,6 @@ enum DataSourceType {
   Indicates a ClickHouse Data Source.
   """
   CLICKHOUSE
-  """
-  Indicates a BigQuery Data Source.
-  """
-  BIGQUERY
   """
   Indicates a Snowflake Data Source.
   """
@@ -1857,17 +1857,13 @@ The fields for querying Data Grid records.
 """
 input DataGridInput {
   """
-  Optionally specifies the Propeller to use. Applications may not set this value. Instead, Application Queries always use the Propeller configured on the Application.
+  The Data Pool to be queried.
   """
-  propeller: Propeller
-  """
-  The ID of the Data Pool to be queried
-  """
-  dataPool: DataPoolInput
+  dataPool: DataPoolInput!
   """
   The time range for retrieving the records.
   """
-  timeRange: TimeRangeInput!
+  timeRange: TimeRangeInput
   """
   The time zone to use. Dates and times are always returned in UTC, but setting the time zone influences relative time ranges and granularities.
 
@@ -1915,13 +1911,9 @@ A Metric Report is a table whose columns include dimensions and Metric values, c
 """
 input MetricReportInput {
   """
-  Optionally specifies the Propeller to use. Applications may not set this value. Instead, Application Queries always use the Propeller configured on the Application.
-  """
-  propeller: Propeller
-  """
   The time range for calculating the Metric Report.
   """
-  timeRange: TimeRangeInput!
+  timeRange: TimeRangeInput
   """
   The time zone to use. Dates and times are always returned in UTC, but setting the time zone influences relative time ranges and granularities.
 
@@ -2581,9 +2573,6 @@ input MigrateMetricInput {
   newDataPoolId: ID!
 }
 
-"""
-The fields for querying a Data Pool.
-"""
 input DataPoolInput @oneOf {
   "The ID of the Data Pool."
   id: ID
@@ -2591,9 +2580,6 @@ input DataPoolInput @oneOf {
   name: String
 }
 
-"""
-The fields for querying a Custom Metric.
-"""
 input CustomMetricQueryInput {
   "The Data Pool to which this Metric belongs."
   dataPool: DataPoolInput!
@@ -2601,17 +2587,11 @@ input CustomMetricQueryInput {
   expression: String!
 }
 
-"""
-The fields for querying a Count Metric.
-"""
 input CountMetricQueryInput {
   "The Data Pool to which this Metric belongs."
   dataPool: DataPoolInput!
 }
 
-"""
-The fields for querying a Sum Metric.
-"""
 input SumMetricQueryInput {
   "The Data Pool to which this Metric belongs."
   dataPool: DataPoolInput!
@@ -2621,9 +2601,6 @@ input SumMetricQueryInput {
   measure: DimensionInput!
 }
 
-"""
-The fields for querying an Average Metric.
-"""
 input AverageMetricQueryInput {
   "The Data Pool to which this Metric belongs."
   dataPool: DataPoolInput!
@@ -2633,9 +2610,6 @@ input AverageMetricQueryInput {
   measure: DimensionInput!
 }
 
-"""
-The fields for querying a Min Metric.
-"""
 input MinMetricQueryInput {
   "The Data Pool to which this Metric belongs."
   dataPool: DataPoolInput!
@@ -2645,9 +2619,6 @@ input MinMetricQueryInput {
   measure: DimensionInput!
 }
 
-"""
-The fields for querying a Max Metric.
-"""
 input MaxMetricQueryInput {
   "The Data Pool to which this Metric belongs."
   dataPool: DataPoolInput!
@@ -2657,9 +2628,6 @@ input MaxMetricQueryInput {
   measure: DimensionInput!
 }
 
-"""
-The fields for querying a Count Distinct Metric.
-"""
 input CountDistinctMetricQueryInput {
   "The Data Pool to which this Metric belongs."
   dataPool: DataPoolInput!
@@ -2669,10 +2637,6 @@ input CountDistinctMetricQueryInput {
   dimension: DimensionInput!
 }
 
-"""
-The fields for querying a Metric.
-The metric query is used to query a Metric in counter, time series, or leaderboard format.
-"""
 input MetricInput @oneOf {
   "The ID of a pre-configured Metric."
   id: ID
@@ -2719,7 +2683,7 @@ input CounterInput {
   """
   The time range for calculating the counter.
   """
-  timeRange: TimeRangeInput!
+  timeRange: TimeRangeInput
   """
   The time zone to use. Dates and times are always returned in UTC, but setting the time zone influences relative time ranges and granularities.
 
@@ -2730,10 +2694,6 @@ input CounterInput {
   The Query Filters to apply before retrieving the counter data. If no Query Filters are provided, all data is included.
   """
   filters: [FilterInput!]
-  """
-  Optionally specifies the Propeller to use. This can be set when querying from the Metric Playground or GraphQL Explorer. Applications may not set this value. Instead, Application Queries always use the Propeller configured on the Application.
-  """
-  propeller: Propeller
 }
 
 """
@@ -2755,13 +2715,13 @@ input TimeSeriesInput {
   """
   metricName: String @deprecated(reason: "Use `metric`")
   """
-  The Metric to query. You can query a pre-configured Metric by ID or name, or you can query an ad hoc Metric that you define inline.
+  The Metric to Query. It can be a pre-created one or it can be inlined here.
   """
   metric: MetricInput
   """
   The time range for calculating the time series.
   """
-  timeRange: TimeRangeInput!
+  timeRange: TimeRangeInput
   """
   The time zone to use. Dates and times are always returned in UTC, but setting the time zone influences relative time ranges and granularities.
 
@@ -2776,10 +2736,6 @@ input TimeSeriesInput {
   The Query Filters to apply before retrieving the time series data. If no Query Filters are provided, all data is included.
   """
   filters: [FilterInput!]
-  """
-  Optionally specifies the Propeller to use. This can be set by Users when querying from the Metric Playground or GraphQL Explorer. Applications may not set this value. Instead, Application Queries always use the Propeller configured on the Application.
-  """
-  propeller: Propeller
 }
 
 """
@@ -2807,7 +2763,7 @@ input LeaderboardInput {
   """
   The time range for calculating the leaderboard.
   """
-  timeRange: TimeRangeInput!
+  timeRange: TimeRangeInput
   """
   The time zone to use. Dates and times are always returned in UTC, but setting the time zone influences relative time ranges and granularities.
 
@@ -2830,10 +2786,6 @@ input LeaderboardInput {
   The list of filters to apply before retrieving the leaderboard data. If no Query Filters are provided, all data is included.
   """
   filters: [FilterInput!]
-  """
-  Optionally specifies the Propeller to use. This can be set by Users when querying from the Metric Playground or GraphQL Explorer. Applications may not set this value. Instead, Application Queries always use the Propeller configured on the Application.
-  """
-  propeller: Propeller
 }
 
 """
@@ -4260,6 +4212,51 @@ type Mutation {
 }
 
 """
+Input to the SqlV1 api.
+"""
+input SqlV1Input {
+  """
+  The SQL query.
+  """
+  query: String!
+}
+
+type SqlColumnResponse {
+  """
+  The name of the returned column.
+  """
+  columnName: String!
+  """
+  The returned column's type.
+  """
+  type: ColumnType!
+  """
+  Whether the column is nullable, meaning whether it accepts a null value.
+  """
+  isNullable: Boolean!
+}
+
+"""
+Response from the SQL API.
+"""
+type SqlResponse {
+  """
+  The column names in the same order as present in the `data` field.
+  """
+  columns: [SqlColumnResponse!]!
+  """
+  The data gathered by the SQL query. The data is returned in an N x M matrix format, where the
+  first dimension are the rows retrieved, and the second dimension are the columns. Each cell
+  can be either a string or null, and the string can represent a number, text, date or boolean value.
+  """
+  rows: [[String]!]!
+  """
+  The Query statistics and metadata.
+  """
+  info: QueryInfo!
+}
+
+"""
 The Data Grid connection.
 
 It includes `headers` and `rows` for a single page of a Data Grid table. It also allows paging forward and backward to other
@@ -4333,17 +4330,9 @@ The fields for querying records by unique ID.
 """
 input RecordsByUniqueIdInput {
   """
-  Optionally specifies the Propeller to use. Applications may not set this value. Instead, Application Queries always use the Propeller configured on the Application.
+  The Data Pool to be queried. A Data Pool ID or unique name can be provided.
   """
-  propeller: Propeller
-  """
-  The Data Pool to be queried. If a Data Pool ID is provided it will take precedence over the Data Pool name.
-  """
-  dataPoolId: ID
-  """
-  The Data Pool to be queried. If a Data Pool ID is provided it will take precedence over the Data Pool name.
-  """
-  dataPoolName: String
+  dataPool: DataPoolInput!
   """
   The columns to retrieve.
   """
@@ -4384,7 +4373,7 @@ input TopValuesInput {
   """
   The time range for calculating the top values.
   """
-  timeRange: TimeRangeInput!
+  timeRange: TimeRangeInput
   """
   The time zone to use. Dates and times are always returned in UTC, but setting the time zone influences relative time ranges and granularities.
 
@@ -4402,120 +4391,6 @@ type TopValuesResponse {
   An array with the list of values.
   """
   values: [String!]!
-}
-
-"""
-Input to the SqlV1 api.
-"""
-input SqlV1Input {
-  """
-  The SQL query.
-  """
-  query: String!
-
-  """
-  Optionally specifies the Propeller to use. Applications may not set this value. Instead, Application Queries always use the Propeller configured on the Application.
-  """
-  propeller: Propeller @tag(name: "internal")
-
-  """
-  query timeout in milliseconds.
-  """
-  timeout: Int @tag(name: "internal")
-}
-
-type SqlColumnResponse {
-  """
-  The name of the returned column.
-  """
-  columnName: String!
-
-  """
-  The returned column's type.
-  """
-  type: ColumnType!
-
-  """
-  Whether the column is nullable, meaning whether it accepts a null value.
-  """
-  isNullable: Boolean!
-}
-
-"""
-Response from the SQL API.
-"""
-type SqlResponse {
-  """
-  The column names in the same order as present in the `data` field.
-  """
-  columns: [SqlColumnResponse!]!
-  """
-  The data gathered by the SQL query. The data is returned in an N x M matrix format, where the
-  first dimension are the rows retrieved, and the second dimension are the columns. Each cell
-  can be either a string or null, and the string can represent a number, text, date or boolean value.
-  """
-  rows: [[String]!]!
-  """
-  The Query statistics and metadata.
-  """
-  info: QueryInfo!
-}
-
-"""
-Input to the SqlV1 api.
-"""
-input SqlV1Input {
-  """
-  The SQL query.
-  """
-  query: String!
-
-  """
-  Optionally specifies the Propeller to use. Applications may not set this value. Instead, Application Queries always use the Propeller configured on the Application.
-  """
-  propeller: Propeller @tag(name: "internal")
-
-  """
-  query timeout in milliseconds.
-  """
-  timeout: Int @tag(name: "internal")
-}
-
-type SqlColumnResponse {
-  """
-  The name of the returned column.
-  """
-  columnName: String!
-
-  """
-  The returned column's type.
-  """
-  type: ColumnType!
-
-  """
-  Whether the column is nullable, meaning whether it accepts a null value.
-  """
-  isNullable: Boolean!
-}
-
-"""
-Response from the SQL API.
-"""
-type SqlResponse {
-  """
-  The column names in the same order as present in the `data` field.
-  """
-  columns: [SqlColumnResponse!]!
-  """
-  The data gathered by the SQL query. The data is returned in an N x M matrix format, where the
-  first dimension are the rows retrieved, and the second dimension are the columns. Each cell
-  can be either a string or null, and the string can represent a number, text, date or boolean value.
-  """
-  rows: [[String]!]!
-  """
-  The Query statistics and metadata.
-  """
-  info: QueryInfo!
 }
 
 type Query {
@@ -4651,13 +4526,13 @@ type Query {
   """
   metricReport(input: MetricReportInput!): MetricReportConnection
   """
+  Query Data Pools using SQL.
+  """
+  sqlV1(input: SqlV1Input!): SqlResponse!
+  """
   This query returns the individual records of a Data Pool with the convenience of built-in pagination, filtering, and sorting.
   """
   dataGrid(input: DataGridInput!): DataGridConnection!
-  """
-  This query returns records by the given unique IDs.
-  """
-  recordsByUniqueId(input: RecordsByUniqueIdInput!): RecordsByUniqueIdResponse!
   """
   This query returns records by the given unique IDs.
   """
@@ -4719,11 +4594,6 @@ type Query {
     last: Int
     before: String
   ): UpdateDataPoolRecordsJobConnection!
-
-  """
-  Query Data Pools using SQL.
-  """
-  sqlV1(input: SqlV1Input!): SqlResponse!
 }
 
 """
@@ -5558,41 +5428,4 @@ input WebhookConnectionSettingsInput {
   The unique ID column. Propel uses the primary timestamp and a unique ID to compose a primary key for determining whether records should be inserted, deleted, or updated.
   """
   uniqueId: String
-}
-
-"""
-The fields for querying records by unique ID.
-"""
-input RecordsByUniqueIdInput {
-  """
-  Optionally specifies the Propeller to use. Applications may not set this value. Instead, Application Queries always use the Propeller configured on the Application.
-  """
-  propeller: Propeller
-  """
-  The Data Pool to be queried. A Data Pool ID or unique name can be provided.
-  """
-  dataPool: DataPoolInput!
-  """
-  The columns to retrieve.
-  """
-  columns: [String!]!
-  """
-  The unique IDs of the records to retrieve.
-  """
-  uniqueIds: [String!]!
-}
-
-type RecordsByUniqueIdResponse {
-  """
-  The Data Pool columns for the record.
-  """
-  columns: [String!]!
-  """
-  An array of values for the record.
-  """
-  values: [[String]!]!
-  """
-  The Query statistics and metadata.
-  """
-  query: QueryInfo!
 }

--- a/packages/ui-kit/src/hooks/useCounter/useCounter.test.tsx
+++ b/packages/ui-kit/src/hooks/useCounter/useCounter.test.tsx
@@ -11,6 +11,13 @@ const mockData = {
 
 const handlers = [
   mockCounterQuery((req, res, ctx) => {
+    const metric = req.variables.counterInput.metricName
+    const timeRange = req.variables.counterInput.timeRange
+
+    if (metric === 'not-receive-timerange' && timeRange != null) {
+      return res(ctx.errors([{ message: 'timeRange should not be provided' }]))
+    }
+
     return res(
       ctx.data({
         counter: mockData
@@ -52,6 +59,12 @@ describe('useCounter', () => {
 
   it('should useCounter return value', async () => {
     dom = render(<QueryClientProviderComponent {...mockQuery} />)
+
+    await dom.findByText(mockData.value)
+  })
+
+  it('should not send timeRange when not provided', async () => {
+    dom = render(<QueryClientProviderComponent accessToken="token" metric="not-receive-timerange" />)
 
     await dom.findByText(mockData.value)
   })

--- a/packages/ui-kit/src/hooks/useCounter/useCounter.ts
+++ b/packages/ui-kit/src/hooks/useCounter/useCounter.ts
@@ -48,6 +48,8 @@ export const useCounter = (props: CounterQueryProps): UseQueryProps<CounterQuery
   // Define metric input
   const metricInput = typeof metric === 'string' ? { metricName: metric } : { metric: metric }
 
+  const withTimeRange = timeRange != null ? { ...timeRange } : {}
+
   /**
    * @hook react-query wrapper
    * @param {CounterQuery} data
@@ -67,12 +69,7 @@ export const useCounter = (props: CounterQueryProps): UseQueryProps<CounterQuery
       counterInput: {
         ...metricInput,
         timeZone: timeZone ?? getTimeZone(),
-        timeRange: {
-          relative: timeRange?.relative ?? null,
-          n: timeRange?.n ?? null,
-          start: timeRange?.start ?? null,
-          stop: timeRange?.stop ?? null
-        },
+        ...withTimeRange,
         filters
       }
     },

--- a/packages/ui-kit/src/hooks/useDataGrid/useDataGrid.test.tsx
+++ b/packages/ui-kit/src/hooks/useDataGrid/useDataGrid.test.tsx
@@ -15,6 +15,13 @@ const mockData = {
 
 const handlers = [
   mockDataGridQuery((req, res, ctx) => {
+    const dataPoolName = req.variables.dataGridInput.dataPool.name
+    const timeRange = req.variables.dataGridInput.timeRange
+
+    if (dataPoolName === 'not-receive-timerange' && timeRange != null) {
+      return res(ctx.errors([{ message: 'timeRange should not be provided' }]))
+    }
+
     return res(
       ctx.data({
         dataGrid: mockData
@@ -77,6 +84,13 @@ describe('useDataGrid', () => {
 
   it('should useDataGrid return value', async () => {
     dom = render(<QueryClientProviderComponent {...mockQuery} />)
+
+    await dom.findByText(mockData.headers[0])
+    await dom.findByText(mockData.rows[0][1])
+  })
+
+  it('should not send timeRange when not provided', async () => {
+    dom = render(<QueryClientProviderComponent accessToken="token" dataPool={{ name: 'not-receive-timerange' }} />)
 
     await dom.findByText(mockData.headers[0])
     await dom.findByText(mockData.rows[0][1])

--- a/packages/ui-kit/src/hooks/useDataGrid/useDataGrid.ts
+++ b/packages/ui-kit/src/hooks/useDataGrid/useDataGrid.ts
@@ -47,6 +47,8 @@ export const useDataGrid = ({
     log.error(accessTokenError ?? 'No access token provided.')
   }
 
+  const withTimeRange = timeRange != null ? { ...timeRange } : {}
+
   const dataPoolInput = dataPool?.name != null ? { name: dataPool.name } : { id: dataPool?.id ?? '' }
 
   /**
@@ -69,12 +71,7 @@ export const useDataGrid = ({
         columns: columns ?? [],
         dataPool: dataPoolInput,
         filters: filters ?? [],
-        timeRange: {
-          relative: timeRange?.relative ?? null,
-          n: timeRange?.n ?? null,
-          start: timeRange?.start ?? null,
-          stop: timeRange?.stop ?? null
-        },
+        ...withTimeRange,
         timeZone,
         orderByColumn,
         sort,

--- a/packages/ui-kit/src/hooks/useLeaderboard/useLeaderboard.test.tsx
+++ b/packages/ui-kit/src/hooks/useLeaderboard/useLeaderboard.test.tsx
@@ -12,6 +12,13 @@ const mockData = {
 
 const handlers = [
   mockLeaderboardQuery((req, res, ctx) => {
+    const metric = req.variables.leaderboardInput.metricName
+    const timeRange = req.variables.leaderboardInput.timeRange
+
+    if (metric === 'not-receive-timerange' && timeRange != null) {
+      return res(ctx.errors([{ message: 'timeRange should not be provided' }]))
+    }
+
     return res(
       ctx.data({
         leaderboard: mockData
@@ -72,6 +79,13 @@ describe('useLeaderboard', () => {
 
   it('should useLeaderboard return value', async () => {
     dom = render(<QueryClientProviderComponent {...mockQuery} />)
+
+    await dom.findByText(mockData.headers[0])
+    await dom.findByText(mockData.rows[0][1])
+  })
+
+  it('should not send timeRange when not provided', async () => {
+    dom = render(<QueryClientProviderComponent accessToken="token" metric="not-receive-timerange" />)
 
     await dom.findByText(mockData.headers[0])
     await dom.findByText(mockData.rows[0][1])

--- a/packages/ui-kit/src/hooks/useLeaderboard/useLeaderboard.ts
+++ b/packages/ui-kit/src/hooks/useLeaderboard/useLeaderboard.ts
@@ -51,6 +51,8 @@ export const useLeaderboard = (props: LeaderboardQueryProps): UseQueryProps<Lead
   // Define metric input
   const metricInput = typeof metric === 'string' ? { metricName: metric } : { metric: metric }
 
+  const withTimeRange = timeRange != null ? { ...timeRange } : {}
+
   /**
    * @hook react-query wrapper
    * @param {LeaderboardQuery} data
@@ -74,12 +76,7 @@ export const useLeaderboard = (props: LeaderboardQueryProps): UseQueryProps<Lead
         rowLimit: rowLimit ?? 100,
         dimensions: dimensions ?? [],
         timeZone: timeZone ?? getTimeZone(),
-        timeRange: {
-          relative: timeRange?.relative ?? null,
-          n: timeRange?.n ?? null,
-          start: timeRange?.start ?? null,
-          stop: timeRange?.stop ?? null
-        }
+        ...withTimeRange
       }
     },
     {

--- a/packages/ui-kit/src/hooks/useTimeSeries/useTimeSeries.test.tsx
+++ b/packages/ui-kit/src/hooks/useTimeSeries/useTimeSeries.test.tsx
@@ -12,6 +12,13 @@ const mockData = {
 
 const handlers = [
   mockTimeSeriesQuery((req, res, ctx) => {
+    const metric = req.variables.timeSeriesInput.metricName
+    const timeRange = req.variables.timeSeriesInput.timeRange
+
+    if (metric === 'not-receive-timerange' && timeRange != null) {
+      return res(ctx.errors([{ message: 'timeRange should not be provided' }]))
+    }
+
     return res(
       ctx.data({
         timeSeries: mockData
@@ -63,6 +70,13 @@ describe('useTimeSeries', () => {
 
   it('should useTimeSeries return value', async () => {
     dom = render(<QueryClientProviderComponent {...mockQuery} />)
+
+    await dom.findByText(mockData.labels[1])
+    await dom.findByText(mockData.values[2])
+  })
+
+  it('should not send timeRange when not provided', async () => {
+    dom = render(<QueryClientProviderComponent accessToken="token" metric="not-receive-timerange" />)
 
     await dom.findByText(mockData.labels[1])
     await dom.findByText(mockData.values[2])

--- a/packages/ui-kit/src/hooks/useTimeSeries/useTimeSeries.ts
+++ b/packages/ui-kit/src/hooks/useTimeSeries/useTimeSeries.ts
@@ -49,6 +49,8 @@ export const useTimeSeries = (props: TimeSeriesQueryProps): UseQueryProps<TimeSe
   // Define metric input
   const metricInput = typeof metric === 'string' ? { metricName: metric } : { metric: metric }
 
+  const withTimeRange = timeRange != null ? { ...timeRange } : {}
+
   /**
    * @hook react-query wrapper
    * @param {TimeSeriesQuery} data
@@ -68,12 +70,7 @@ export const useTimeSeries = (props: TimeSeriesQueryProps): UseQueryProps<TimeSe
       timeSeriesInput: {
         ...metricInput,
         timeZone,
-        timeRange: {
-          relative: timeRange?.relative ?? null,
-          n: timeRange?.n ?? null,
-          start: timeRange?.start ?? null,
-          stop: timeRange?.stop ?? null
-        },
+        ...withTimeRange,
         granularity: granularity as TimeSeriesGranularity,
         filters
       }

--- a/packages/ui-kit/src/hooks/useTopValues/useTopValues.test.tsx
+++ b/packages/ui-kit/src/hooks/useTopValues/useTopValues.test.tsx
@@ -11,6 +11,13 @@ const mockData = {
 
 const handlers = [
   mockTopValuesQuery((req, res, ctx) => {
+    const dataPoolName = req.variables.topValuesInput.dataPool.name
+    const timeRange = req.variables.topValuesInput.timeRange
+
+    if (dataPoolName === 'not-receive-timerange' && timeRange != null) {
+      return res(ctx.errors([{ message: 'timeRange should not be provided' }]))
+    }
+
     return res(
       ctx.data({
         topValues: mockData
@@ -62,6 +69,12 @@ describe('useTopValues', () => {
 
   it('should useTopValues return value', async () => {
     dom = render(<QueryClientProviderComponent {...mockQuery} />)
+
+    await dom.findByText(mockData.values[2])
+  })
+
+  it('should not send timeRange when not provided', async () => {
+    dom = render(<QueryClientProviderComponent accessToken="token" dataPool={{ name: 'not-receive-timerange' }} />)
 
     await dom.findByText(mockData.values[2])
   })

--- a/packages/ui-kit/src/hooks/useTopValues/useTopValues.ts
+++ b/packages/ui-kit/src/hooks/useTopValues/useTopValues.ts
@@ -44,6 +44,8 @@ export const useTopValues = ({
 
   const dataPoolInput = dataPool?.name != null ? { name: dataPool.name } : { id: dataPool?.id ?? '' }
 
+  const withTimeRange = timeRange != null ? { ...timeRange } : {}
+
   /**
    * @hook react-query wrapper
    * @param {TopValuesQuery} data
@@ -64,12 +66,7 @@ export const useTopValues = ({
         columnName: columnName ?? '',
         dataPool: dataPoolInput,
         maxValues,
-        timeRange: {
-          relative: timeRange?.relative ?? null,
-          n: timeRange?.n ?? null,
-          start: timeRange?.start ?? null,
-          stop: timeRange?.stop ?? null
-        },
+        ...withTimeRange,
         timeZone
       }
     },


### PR DESCRIPTION
## Description of changes

Currently query hooks pass an object with empty values for timeRange even when this one is not provided, this was not a problem as timeRange was required.

```json
{
  "relative": null,
  "n": null,
  "start": null,
  "stop": null
}
```

Now that it's not required this ends up causing 400s in the API, disabling users to not pass the timeRange prop.

This PR removes this behavior and ensure nothing is passed when timeRange is not passed.

## Checklist

Before merging to main:

- [x] Tests
- [x] Manually tested in React apps
- [ ] Changesets
- [ ] Approved
