### PR TITLE
Fix chartConfigProps not passing props to the components

### DIFF
--- a/.changeset/twelve-fishes-lay.md
+++ b/.changeset/twelve-fishes-lay.md
@@ -1,0 +1,5 @@
+---
+'@propeldata/ui-kit': patch
+---
+
+Fixed chartConfigProps not passing some props

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -51,6 +51,9 @@ jobs:
         with:
           cache_fresh_start: 'true'
 
+      - name: Set up npm authentication
+      run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+
       # Release
       - name: Prerelease Version and Publish
         id: changesets

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -51,14 +51,12 @@ jobs:
         with:
           cache_fresh_start: 'true'
 
-      - name: Set up npm authentication
-      run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
-
       # Release
       - name: Prerelease Version and Publish
         id: changesets
         run: |
           yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
           yarn changeset version --snapshot canary
           yarn changeset publish --tag canary --no-git-tag
         env:

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -54,11 +54,10 @@ jobs:
       # Release
       - name: Prerelease Version and Publish
         id: changesets
-        uses: changesets/action@v1
-        with:
-          version: yarn changeset version --snapshot
-          publish: yarn release --pre
-          commit: "chore: canary release"
+        run: |
+          yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
+          yarn changeset version --snapshot canary
+          yarn changeset publish --tag canary --no-git-tag
         env:
           GITHUB_TOKEN: ${{ secrets.PROPELDATA_CI_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -57,7 +57,7 @@ jobs:
         uses: changesets/action@v1
         with:
           version: yarn changeset version --snapshot
-          publish: yarn release
+          publish: yarn release --pre
         env:
           GITHUB_TOKEN: ${{ secrets.PROPELDATA_CI_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -53,12 +53,9 @@ jobs:
 
       # Release
       - name: Prerelease Version and Publish
-        id: changesets
         run: |
           yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
-          yarn changeset version --snapshot canary
-          yarn changeset publish --tag canary --no-git-tag
-        env:
-          GITHUB_TOKEN: ${{ secrets.PROPELDATA_CI_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          git config --global user.email "engineering@propeldata.com"
+          git config --global user.name "Propel Data Cloud, Inc."
+          yarn changeset version --snapshot
+          yarn release --pre

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -57,8 +57,4 @@ jobs:
         uses: changesets/action@v1
         with:
           version: yarn changeset version --snapshot
-        run: |
-          yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
-          git config --global user.email "engineering@propeldata.com"
-          git config --global user.name "Propel Data Cloud, Inc."
-          yarn release --pre
+          publish: yarn release

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -53,9 +53,12 @@ jobs:
 
       # Release
       - name: Prerelease Version and Publish
+        id: changesets
         run: |
           yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
-          git config --global user.email "engineering@propeldata.com"
-          git config --global user.name "Propel Data Cloud, Inc."
-          yarn changeset version --snapshot
-          yarn release --pre
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+          yarn changeset version --snapshot canary
+          yarn changeset publish --tag canary --no-git-tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROPELDATA_CI_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           version: yarn changeset version --snapshot
           publish: yarn release --pre
+          commit: "chore: canary release"
         env:
           GITHUB_TOKEN: ${{ secrets.PROPELDATA_CI_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -58,3 +58,6 @@ jobs:
         with:
           version: yarn changeset version --snapshot
           publish: yarn release
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROPELDATA_CI_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -53,9 +53,12 @@ jobs:
 
       # Release
       - name: Prerelease Version and Publish
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: yarn changeset version --snapshot
         run: |
           yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
           git config --global user.email "engineering@propeldata.com"
-          git config --global user.name "Propel Data Cloud, Inc." 
-          yarn changeset version --snapshot
+          git config --global user.name "Propel Data Cloud, Inc."
           yarn release --pre

--- a/packages/ui-kit/src/components/Leaderboard/Leaderboard.stories.tsx
+++ b/packages/ui-kit/src/components/Leaderboard/Leaderboard.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryContext, StoryObj } from '@storybook/react'
-import React from 'react'
+import React, { useState } from 'react'
 import axiosInstance from '../../../../../app/storybook/src/axios'
 import {
   quotedStringRegex,
@@ -11,6 +11,8 @@ import {
 import { Leaderboard as LeaderboardSource, LeaderboardComponent } from './Leaderboard'
 import './Leaderboard.stories.css'
 import rawLeaderboardCss from '!!raw-loader!./Leaderboard.stories.css'
+import { DefaultThemes, ThemeProvider } from '../ThemeProvider'
+import { ThemeTokenProps } from '../../themes'
 
 const meta: Meta<typeof LeaderboardComponent> = {
   title: 'Components/Leaderboard',
@@ -283,7 +285,7 @@ export const CustomStyleStory: Story = {
     `,
     codeTemplate: (body: string, context: StoryContext): string => `
       // Leaderboard.tsx
-      
+
       import { ${context?.parameters?.imports ?? ''} } from '@propeldata/ui-kit'
       import './Leaderboard.css'
 
@@ -304,5 +306,44 @@ export const CustomStyleStory: Story = {
       stickyHeader: true
     }
   },
+  render: (args) => <Leaderboard {...args} />
+}
+
+export const ThemeStory: Story = {
+  name: 'Theme',
+  args: {
+    headers: barHeaders,
+    rows: barRows,
+    card: true
+  },
+  decorators: [
+    (Story) => {
+      const [baseTheme, setBaseTheme] = useState<DefaultThemes>('lightTheme')
+
+      const lightColors: ThemeTokenProps = {
+        accent: '#3d3d3d',
+        accentHover: '#3d3d3dc6'
+      }
+
+      const darkColors: ThemeTokenProps = {
+        accent: '#adadad',
+        accentHover: '#ffffffc6'
+      }
+
+      const theme = baseTheme === 'darkTheme' ? darkColors : lightColors
+
+      return (
+        <ThemeProvider baseTheme={baseTheme} theme={theme}>
+          <div style={{ margin: '10px', display: 'flex', gap: '8px' }}>
+            <button type="button" onClick={() => setBaseTheme(baseTheme === 'darkTheme' ? 'lightTheme' : 'darkTheme')}>
+              Switch theme
+            </button>
+            <span>{baseTheme}</span>
+          </div>
+          <Story />
+        </ThemeProvider>
+      )
+    }
+  ],
   render: (args) => <Leaderboard {...args} />
 }

--- a/packages/ui-kit/src/components/Leaderboard/Leaderboard.tsx
+++ b/packages/ui-kit/src/components/Leaderboard/Leaderboard.tsx
@@ -173,8 +173,7 @@ export const LeaderboardComponent = React.forwardRef<HTMLDivElement, Leaderboard
           chart.data.datasets[0].data = values
           chart.options.plugins = {
             ...chart.options.plugins,
-            ...customPlugins,
-            ...config?.options?.plugins
+            ...customPlugins
           }
 
           if (chart.options.scales?.x && 'border' in chart.options.scales.x && chart.options.scales.x.border) {
@@ -188,9 +187,10 @@ export const LeaderboardComponent = React.forwardRef<HTMLDivElement, Leaderboard
           }
 
           chart.options.scales = {
-            ...chart.options.scales,
-            ...config?.options?.scales
+            ...chart.options.scales
           }
+
+          chartConfigProps?.(chart.config as ChartConfiguration<'bar'>)
 
           chart.update()
           return

--- a/packages/ui-kit/src/components/Leaderboard/Leaderboard.tsx
+++ b/packages/ui-kit/src/components/Leaderboard/Leaderboard.tsx
@@ -170,11 +170,18 @@ export const LeaderboardComponent = React.forwardRef<HTMLDivElement, Leaderboard
         if (chartRef.current) {
           const chart = chartRef.current
           chart.data.labels = labels
-          chart.data.datasets[0].data = values
           chart.options.plugins = {
             ...chart.options.plugins,
-            ...customPlugins
+            ...customPlugins,
+            ...config?.options?.plugins
           }
+
+          chart.data.datasets[0].data = values
+          Object.assign(chart.data.datasets[0], {
+            type: variant,
+            ...chart.data.datasets,
+            ...config?.data.datasets[0]
+          })
 
           if (chart.options.scales?.x && 'border' in chart.options.scales.x && chart.options.scales.x.border) {
             chart.options.scales.x.border = { ...chart.options.scales.x.border, color: theme.colorSecondary }
@@ -187,10 +194,9 @@ export const LeaderboardComponent = React.forwardRef<HTMLDivElement, Leaderboard
           }
 
           chart.options.scales = {
-            ...chart.options.scales
+            ...chart.options.scales,
+            ...config?.options?.scales
           }
-
-          chartConfigProps?.(chart.config as ChartConfiguration<'bar'>)
 
           chart.update()
           return

--- a/packages/ui-kit/src/components/Leaderboard/Leaderboard.tsx
+++ b/packages/ui-kit/src/components/Leaderboard/Leaderboard.tsx
@@ -97,30 +97,6 @@ export const LeaderboardComponent = React.forwardRef<HTMLDivElement, Leaderboard
           customChartLabelsPlugin
         }
 
-        if (chartRef.current) {
-          const chart = chartRef.current
-          chart.data.labels = labels
-          chart.data.datasets[0].data = values
-          chart.options.plugins = {
-            ...chart.options.plugins,
-            ...customPlugins
-          }
-
-          // @TODO: need improvement
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          chart.options.scales.x.border.color = theme?.colorSecondary
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          chart.options.scales.x.grid.color = theme?.colorSecondary
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          chart.options.scales.y.grid.color = theme?.colorSecondary
-
-          chart.update()
-          return
-        }
-
         let config: ChartConfiguration<'bar'> = {
           ...chartConfig,
           type: 'bar',
@@ -185,6 +161,37 @@ export const LeaderboardComponent = React.forwardRef<HTMLDivElement, Leaderboard
             }
           },
           plugins: [customCanvasBackgroundColor, customChartLabelsPlugin]
+        }
+
+        if (chartRef.current) {
+          const customConfig = chartConfigProps?.(config)
+
+          const chart = chartRef.current
+          chart.data.labels = labels
+          chart.data.datasets[0].data = values
+          chart.options.plugins = {
+            ...chart.options.plugins,
+            ...customPlugins,
+            ...customConfig?.options?.plugins
+          }
+
+          if (chart.options.scales?.x && 'border' in chart.options.scales.x && chart.options.scales.x.border) {
+            chart.options.scales.x.border = { ...chart.options.scales.x.border, color: theme.colorSecondary }
+          }
+          if (chart.options.scales?.x?.grid != null) {
+            chart.options.scales.x.grid = { ...chart.options.scales.x.grid, color: theme.colorSecondary }
+          }
+          if (chart.options.scales?.y?.grid != null) {
+            chart.options.scales.y.grid = { ...chart.options.scales.y.grid, color: theme.colorSecondary }
+          }
+
+          chart.options.scales = {
+            ...chart.options.scales,
+            ...customConfig?.options?.scales
+          }
+
+          chart.update()
+          return
         }
 
         if (chartConfigProps) {

--- a/packages/ui-kit/src/components/Leaderboard/Leaderboard.tsx
+++ b/packages/ui-kit/src/components/Leaderboard/Leaderboard.tsx
@@ -163,16 +163,18 @@ export const LeaderboardComponent = React.forwardRef<HTMLDivElement, Leaderboard
           plugins: [customCanvasBackgroundColor, customChartLabelsPlugin]
         }
 
-        if (chartRef.current) {
-          const customConfig = chartConfigProps?.(config)
+        if (chartConfigProps) {
+          config = chartConfigProps(config)
+        }
 
+        if (chartRef.current) {
           const chart = chartRef.current
           chart.data.labels = labels
           chart.data.datasets[0].data = values
           chart.options.plugins = {
             ...chart.options.plugins,
             ...customPlugins,
-            ...customConfig?.options?.plugins
+            ...config?.options?.plugins
           }
 
           if (chart.options.scales?.x && 'border' in chart.options.scales.x && chart.options.scales.x.border) {
@@ -187,15 +189,11 @@ export const LeaderboardComponent = React.forwardRef<HTMLDivElement, Leaderboard
 
           chart.options.scales = {
             ...chart.options.scales,
-            ...customConfig?.options?.scales
+            ...config?.options?.scales
           }
 
           chart.update()
           return
-        }
-
-        if (chartConfigProps) {
-          config = chartConfigProps(config)
         }
 
         chartRef.current = new ChartJS(canvasRef.current, config)

--- a/packages/ui-kit/src/components/PieChart/PieChart.stories.tsx
+++ b/packages/ui-kit/src/components/PieChart/PieChart.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import React from 'react'
+import React, { useState } from 'react'
 import axiosInstance from '../../../../../app/storybook/src/axios'
 import {
   quotedStringRegex,
@@ -8,6 +8,8 @@ import {
   storybookCodeTemplate,
   useStorybookAccessToken
 } from '../../helpers'
+import { ThemeTokenProps } from '../../themes'
+import { DefaultThemes, ThemeProvider } from '../ThemeProvider'
 import { PieChart as PieChartSource, PieChartComponent } from './PieChart'
 
 const meta: Meta<typeof PieChartComponent> = {
@@ -232,5 +234,61 @@ export const ShowValuesDoughnutStory: Story = {
     },
     card: true
   },
+  render: (args) => <PieChart {...args} />
+}
+
+export const ThemeStory: Story = {
+  name: 'Theme',
+  args: {
+    variant: 'pie',
+    headers: pieHeaders,
+    rows: pieRows,
+    card: true
+  },
+  decorators: [
+    (Story) => {
+      const [baseTheme, setBaseTheme] = useState<DefaultThemes>('lightTheme')
+
+      const lightColors: ThemeTokenProps = {
+        colorBlue950: '#1a1919',
+        colorBlue900: '#2D3748',
+        colorBlue800: '#4A5568',
+        colorBlue700: '#718096',
+        colorBlue600: '#A0AEC0',
+        colorBlue500: '#CBD5E0',
+        colorBlue400: '#E2E8F0',
+        colorBlue300: '#EDF2F7',
+        colorBlue200: '#F7FAFC',
+        colorBlue100: '#FFFFFF'
+      }
+
+      const darkColors: ThemeTokenProps = {
+        colorBlue950: '#d9d9d9',
+        colorBlue900: '#F7FAFC',
+        colorBlue800: '#EDF2F7',
+        colorBlue700: '#E2E8F0',
+        colorBlue600: '#CBD5E0',
+        colorBlue500: '#A0AEC0',
+        colorBlue400: '#718096',
+        colorBlue300: '#4A5568',
+        colorBlue200: '#2D3748',
+        colorBlue100: '#1a1919'
+      }
+
+      const theme = baseTheme === 'darkTheme' ? darkColors : lightColors
+
+      return (
+        <ThemeProvider baseTheme={baseTheme} theme={theme}>
+          <div style={{ margin: '10px', display: 'flex', gap: '8px' }}>
+            <button type="button" onClick={() => setBaseTheme(baseTheme === 'darkTheme' ? 'lightTheme' : 'darkTheme')}>
+              Switch theme
+            </button>
+            <span>{baseTheme}</span>
+          </div>
+          <Story />
+        </ThemeProvider>
+      )
+    }
+  ],
   render: (args) => <PieChart {...args} />
 }

--- a/packages/ui-kit/src/components/PieChart/PieChart.tsx
+++ b/packages/ui-kit/src/components/PieChart/PieChart.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Chart as ChartJS, ChartConfiguration, Plugin } from 'chart.js/auto'
+import { Chart as ChartJS, ChartConfiguration, ChartTypeRegistry, Plugin, PluginOptionsByType } from 'chart.js/auto'
+import { _DeepPartialObject } from 'chart.js/dist/types/utils'
 import classnames from 'classnames'
 import componentStyles from './PieChart.module.scss'
 
@@ -192,6 +193,8 @@ export const PieChartComponent = React.forwardRef<HTMLDivElement, PieChartProps>
         }
 
         if (chartRef.current) {
+          const customConfig = chartConfigProps?.(config)
+
           const chart = chartRef.current
 
           chart.data.labels = labels
@@ -199,15 +202,15 @@ export const PieChartComponent = React.forwardRef<HTMLDivElement, PieChartProps>
             type: variant,
             data: values,
             backgroundColor: chartColorPalette,
-            ...datasets
+            ...datasets,
+            ...customConfig?.data.datasets[0]
           })
 
           chart.options.plugins = {
             ...chart.options.plugins,
-            ...customPlugins
+            ...customPlugins,
+            ...(customConfig?.options?.plugins as _DeepPartialObject<PluginOptionsByType<keyof ChartTypeRegistry>>)
           }
-
-          chartConfigProps?.(chart.config as ChartConfiguration<'pie' | 'doughnut'>)
 
           chart.update()
           return

--- a/packages/ui-kit/src/components/PieChart/PieChart.tsx
+++ b/packages/ui-kit/src/components/PieChart/PieChart.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import { Chart as ChartJS, ChartConfiguration, Plugin } from 'chart.js/auto'
+import { Chart as ChartJS, ChartConfiguration, ChartTypeRegistry, Plugin, PluginOptionsByType } from 'chart.js/auto'
+import { _DeepPartialObject } from 'chart.js/dist/types/utils'
 import classnames from 'classnames'
 import componentStyles from './PieChart.module.scss'
 
@@ -147,26 +148,6 @@ export const PieChartComponent = React.forwardRef<HTMLDivElement, PieChartProps>
 
         const datasets = isDoughnut ? { cutout: '75%' } : { cutout: '0' }
 
-        if (chartRef.current) {
-          const chart = chartRef.current
-
-          chart.data.labels = labels
-          Object.assign(chart.data.datasets[0], {
-            type: variant,
-            data: values,
-            backgroundColor: chartColorPalette,
-            ...datasets
-          })
-
-          chart.options.plugins = {
-            ...chart.options.plugins,
-            ...customPlugins
-          }
-
-          chart.update()
-          return
-        }
-
         let config: ChartConfiguration<'pie' | 'doughnut'> = {
           ...chartConfig,
           type: variant,
@@ -205,6 +186,30 @@ export const PieChartComponent = React.forwardRef<HTMLDivElement, PieChartProps>
             }
           },
           plugins: [customCanvasBackgroundColor, customChartLabelsPlugin]
+        }
+
+        if (chartRef.current) {
+          const customConfig = chartConfigProps?.(config)
+
+          const chart = chartRef.current
+
+          chart.data.labels = labels
+          Object.assign(chart.data.datasets[0], {
+            type: variant,
+            data: values,
+            backgroundColor: chartColorPalette,
+            ...datasets,
+            ...customConfig?.data.datasets[0]
+          })
+
+          chart.options.plugins = {
+            ...chart.options.plugins,
+            ...customPlugins,
+            ...(customConfig?.options?.plugins as _DeepPartialObject<PluginOptionsByType<keyof ChartTypeRegistry>>)
+          }
+
+          chart.update()
+          return
         }
 
         if (chartConfigProps) {

--- a/packages/ui-kit/src/components/PieChart/PieChart.tsx
+++ b/packages/ui-kit/src/components/PieChart/PieChart.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import { Chart as ChartJS, ChartConfiguration, ChartTypeRegistry, Plugin, PluginOptionsByType } from 'chart.js/auto'
-import { _DeepPartialObject } from 'chart.js/dist/types/utils'
+import { Chart as ChartJS, ChartConfiguration, Plugin } from 'chart.js/auto'
 import classnames from 'classnames'
 import componentStyles from './PieChart.module.scss'
 
@@ -193,8 +192,6 @@ export const PieChartComponent = React.forwardRef<HTMLDivElement, PieChartProps>
         }
 
         if (chartRef.current) {
-          const customConfig = chartConfigProps?.(config)
-
           const chart = chartRef.current
 
           chart.data.labels = labels
@@ -202,15 +199,15 @@ export const PieChartComponent = React.forwardRef<HTMLDivElement, PieChartProps>
             type: variant,
             data: values,
             backgroundColor: chartColorPalette,
-            ...datasets,
-            ...customConfig?.data.datasets[0]
+            ...datasets
           })
 
           chart.options.plugins = {
             ...chart.options.plugins,
-            ...customPlugins,
-            ...(customConfig?.options?.plugins as _DeepPartialObject<PluginOptionsByType<keyof ChartTypeRegistry>>)
+            ...customPlugins
           }
+
+          chartConfigProps?.(chart.config as ChartConfiguration<'pie' | 'doughnut'>)
 
           chart.update()
           return

--- a/packages/ui-kit/src/components/PieChart/PieChart.tsx
+++ b/packages/ui-kit/src/components/PieChart/PieChart.tsx
@@ -188,6 +188,10 @@ export const PieChartComponent = React.forwardRef<HTMLDivElement, PieChartProps>
           plugins: [customCanvasBackgroundColor, customChartLabelsPlugin]
         }
 
+        if (chartConfigProps) {
+          config = chartConfigProps(config)
+        }
+
         if (chartRef.current) {
           const customConfig = chartConfigProps?.(config)
 
@@ -210,10 +214,6 @@ export const PieChartComponent = React.forwardRef<HTMLDivElement, PieChartProps>
 
           chart.update()
           return
-        }
-
-        if (chartConfigProps) {
-          config = chartConfigProps(config)
         }
 
         chartRef.current = new ChartJS(canvasRef.current, config) as ChartJS

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.stories.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Chart } from 'chart.js'
-import React from 'react'
+import React, { useState } from 'react'
 import axiosInstance from '../../../../../app/storybook/src/axios'
 import {
   quotedStringRegex,
@@ -9,6 +9,8 @@ import {
   TimeSeriesGranularity,
   useStorybookAccessToken
 } from '../../helpers'
+import { ThemeTokenProps } from '../../themes'
+import { DefaultThemes, ThemeProvider } from '../ThemeProvider'
 import { TimeSeries as TimeSeriesSource, TimeSeriesComponent } from './TimeSeries'
 
 const meta: Meta<typeof TimeSeriesComponent> = {
@@ -322,5 +324,44 @@ export const ErrorStory: Story = {
       }
     }
   },
+  render: (args) => <TimeSeries {...args} />
+}
+
+export const ThemeStory: Story = {
+  name: 'Theme',
+  args: {
+    variant: 'bar',
+    card: true,
+    ...dataset
+  },
+  decorators: [
+    (Story) => {
+      const [baseTheme, setBaseTheme] = useState<DefaultThemes>('lightTheme')
+
+      const lightColors: ThemeTokenProps = {
+        accent: '#3d3d3d',
+        accentHover: '#3d3d3dc6'
+      }
+
+      const darkColors: ThemeTokenProps = {
+        accent: '#adadad',
+        accentHover: '#ffffffc6'
+      }
+
+      const theme = baseTheme === 'darkTheme' ? darkColors : lightColors
+
+      return (
+        <ThemeProvider baseTheme={baseTheme} theme={theme}>
+          <div style={{ margin: '10px', display: 'flex', gap: '8px' }}>
+            <button type="button" onClick={() => setBaseTheme(baseTheme === 'darkTheme' ? 'lightTheme' : 'darkTheme')}>
+              Switch theme
+            </button>
+            <span>{baseTheme}</span>
+          </div>
+          <Story />
+        </ThemeProvider>
+      )
+    }
+  ],
   render: (args) => <TimeSeries {...args} />
 }

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
@@ -210,17 +210,23 @@ export const TimeSeriesComponent = React.forwardRef<HTMLDivElement, TimeSeriesPr
           chart.data.labels = labels
           chart.options.scales = {
             ...chart.options.scales,
-            ...scales
+            ...scales,
+            ...config?.options?.scales
           }
           chart.options.plugins = {
             ...chart.options.plugins,
-            ...customPlugins
+            ...customPlugins,
+            ...config?.options?.plugins
           }
 
           const dataset = chart.data.datasets[0]
           dataset.data = values
 
-          chartConfigProps?.(chart.config as never)
+          Object.assign(chart.data.datasets[0], {
+            type: variant,
+            ...chart.data.datasets,
+            ...config?.data.datasets[0]
+          })
 
           chart.update()
           return

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
@@ -210,17 +210,17 @@ export const TimeSeriesComponent = React.forwardRef<HTMLDivElement, TimeSeriesPr
           chart.data.labels = labels
           chart.options.scales = {
             ...chart.options.scales,
-            ...scales,
-            ...config?.options?.scales
+            ...scales
           }
           chart.options.plugins = {
             ...chart.options.plugins,
-            ...customPlugins,
-            ...config?.options?.plugins
+            ...customPlugins
           }
 
           const dataset = chart.data.datasets[0]
           dataset.data = values
+
+          chartConfigProps?.(chart.config as never)
 
           chart.update()
           return

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
@@ -179,25 +179,6 @@ export const TimeSeriesComponent = React.forwardRef<HTMLDivElement, TimeSeriesPr
         // @TODO: need to refactor this logic
         const scales = getScales({ granularity, isFormatted, zone, chart: chartRef.current, variant, grid, theme })
 
-        if (chartRef.current) {
-          const chart = chartRef.current
-          chart.data.labels = labels
-          chart.options.scales = {
-            ...chart.options.scales,
-            ...scales
-          }
-          chart.options.plugins = {
-            ...chart.options.plugins,
-            ...customPlugins
-          }
-
-          const dataset = chart.data.datasets[0]
-          dataset.data = values
-
-          chart.update()
-          return
-        }
-
         const options: ChartOptions<TimeSeriesChartVariant> = {
           responsive: true,
           maintainAspectRatio: false,
@@ -214,6 +195,32 @@ export const TimeSeriesComponent = React.forwardRef<HTMLDivElement, TimeSeriesPr
           data: dataset,
           options,
           plugins
+        }
+
+        if (chartRef.current) {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore
+          const customConfig = chartConfigProps?.(config)
+
+          const chart = chartRef.current
+
+          chart.data.labels = labels
+          chart.options.scales = {
+            ...chart.options.scales,
+            ...scales,
+            ...customConfig?.options?.scales
+          }
+          chart.options.plugins = {
+            ...chart.options.plugins,
+            ...customPlugins,
+            ...customConfig?.options?.plugins
+          }
+
+          const dataset = chart.data.datasets[0]
+          dataset.data = values
+
+          chart.update()
+          return
         }
 
         if (chartConfigProps) {

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
@@ -197,23 +197,26 @@ export const TimeSeriesComponent = React.forwardRef<HTMLDivElement, TimeSeriesPr
           plugins
         }
 
-        if (chartRef.current) {
+        if (chartConfigProps) {
+          // @TODO: fix this complex type
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-ignore
-          const customConfig = chartConfigProps?.(config)
+          config = chartConfigProps(config)
+        }
 
+        if (chartRef.current) {
           const chart = chartRef.current
 
           chart.data.labels = labels
           chart.options.scales = {
             ...chart.options.scales,
             ...scales,
-            ...customConfig?.options?.scales
+            ...config?.options?.scales
           }
           chart.options.plugins = {
             ...chart.options.plugins,
             ...customPlugins,
-            ...customConfig?.options?.plugins
+            ...config?.options?.plugins
           }
 
           const dataset = chart.data.datasets[0]
@@ -221,13 +224,6 @@ export const TimeSeriesComponent = React.forwardRef<HTMLDivElement, TimeSeriesPr
 
           chart.update()
           return
-        }
-
-        if (chartConfigProps) {
-          // @TODO: fix this complex type
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          // @ts-ignore
-          config = chartConfigProps(config)
         }
 
         chartRef.current = new ChartJS(canvasRef.current, config)


### PR DESCRIPTION
## Description of changes

### Problem:
When passing style changes to the `chartConfigProps` those are overriden on re-render by the default style, this is because we are not passing `chartConfigProps` to the chart options on update, here is an example of the bug:

https://github.com/propeldata/ui-kit/assets/84721399/19e789b2-7622-4aa4-9a03-19f907785175

### Approach:
Setting the chart options when the chart is updated as recommended in [chart.js docs](https://www.chartjs.org/docs/latest/developers/updates.html), here is an example with `scales` where `config` is the modified configuration using `chartConfigProps`
```
  chart.options.scales = {
    ...chart.options.scales,
    ...scales,
    ...config?.options?.scales
  }
```

### Other approaches:
Using `chartConfigProps` and passing it the chart instance reference to mutate the properties, we decided not to use this approach as this was causing unexpected bugs such as the chart being re-instantiated for some use cases.
```
  chartConfigProps(chart.config)
```

## Checklist

Before merging to main:

- [ ] Tests
- [x] Manually tested in React apps
- [x] Changesets
- [x] Approved
