### PR TITLE
Fix `canary-release` workflow

### DIFF
--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -53,9 +53,12 @@ jobs:
 
       # Release
       - name: Prerelease Version and Publish
+        id: changesets
         run: |
           yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
-          git config --global user.email "engineering@propeldata.com"
-          git config --global user.name "Propel Data Cloud, Inc." 
-          yarn changeset version --snapshot
-          yarn release --pre
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+          yarn changeset version --snapshot canary
+          yarn changeset publish --tag canary --no-git-tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.PROPELDATA_CI_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -22,6 +22,7 @@ jobs:
           token: ${{ secrets.PROPELDATA_CI_TOKEN }}
           # NOTE(mroberts): https://github.com/actions/checkout/issues/217
           fetch-depth: '0'
+          ref: ${{ github.event.inputs.branch }}
       - uses: actions/checkout@v3
         with:
           repository: propeldata/actions
@@ -50,11 +51,6 @@ jobs:
       - uses: ./.github/actions/prepare
         with:
           cache_fresh_start: 'true'
-
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.inputs.branch }}
 
       # Release
       - name: Prerelease Version and Publish

--- a/.github/workflows/publish-canary.yml
+++ b/.github/workflows/publish-canary.yml
@@ -51,6 +51,11 @@ jobs:
         with:
           cache_fresh_start: 'true'
 
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
       # Release
       - name: Prerelease Version and Publish
         id: changesets

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,18 +1,17 @@
-name: publish-canary
+name: publish-release
 
 on:
-  workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Branch to create a canary from'
-        required: true
+  push:
+    branches:
+      - main
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 env:
   PROPELDATA_CI_TOKEN: ${{ secrets.PROPELDATA_CI_TOKEN }}
 
 jobs:
   publish:
-    if: github.event.head_commit.message != 'release'
     runs-on: ubuntu-latest
     steps:
       # Setup
@@ -51,14 +50,14 @@ jobs:
         with:
           cache_fresh_start: 'true'
 
-      # Release
-      - name: Prerelease Version and Publish
+      # Publish
+      - name: Create Release Pull Request or Publish to npm
         id: changesets
-        run: |
-          yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
-          yarn changeset version --snapshot canary
-          yarn changeset publish --tag canary --no-git-tag
+        uses: changesets/action@v1
+        with:
+          commit: 'ci: Version Packages'
+          version: yarn changeset version
+          publish: yarn release
         env:
           GITHUB_TOKEN: ${{ secrets.PROPELDATA_CI_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,17 +1,18 @@
-name: publish-release
+name: publish-canary
 
 on:
-  push:
-    branches:
-      - main
-
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to create a canary from'
+        required: true
 
 env:
   PROPELDATA_CI_TOKEN: ${{ secrets.PROPELDATA_CI_TOKEN }}
 
 jobs:
   publish:
+    if: github.event.head_commit.message != 'release'
     runs-on: ubuntu-latest
     steps:
       # Setup
@@ -50,14 +51,14 @@ jobs:
         with:
           cache_fresh_start: 'true'
 
-      # Publish
-      - name: Create Release Pull Request or Publish to npm
+      # Release
+      - name: Prerelease Version and Publish
         id: changesets
-        uses: changesets/action@v1
-        with:
-          commit: 'ci: Version Packages'
-          version: yarn changeset version
-          publish: yarn release
+        run: |
+          yarn config set -H 'npmAuthToken' "${{secrets.NPM_TOKEN}}"
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+          yarn changeset version --snapshot canary
+          yarn changeset publish --tag canary --no-git-tag
         env:
           GITHUB_TOKEN: ${{ secrets.PROPELDATA_CI_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Description of changes

This PR fixes the `canary-release` workflow which wasn't creating canary releases

## Checklist

Before merging to main:

- [ ] Tests
- [ ] Manually tested in React apps
- [ ] Changesets
- [ ] Approved
