### PR TITLE
Fix `errorFallbackProps` not being passed correctly

### DIFF
--- a/.changeset/spotty-stingrays-heal.md
+++ b/.changeset/spotty-stingrays-heal.md
@@ -1,0 +1,5 @@
+---
+'@propeldata/ui-kit': patch
+---
+
+Fixed errorFallbackProps not being passed correctly

--- a/packages/ui-kit/src/components/Counter/Counter.test.tsx
+++ b/packages/ui-kit/src/components/Counter/Counter.test.tsx
@@ -170,4 +170,20 @@ describe('Counter', () => {
 
     await sleep(100)
   })
+
+  it('Should receive errorFallbackProp', () => {
+    dom = render(
+      <Counter
+        errorFallbackProps={{
+          error: {
+            title: 'Custom title',
+            body: 'Custom body'
+          }
+        }}
+      />
+    )
+
+    dom.getByText('Custom title')
+    dom.getByText('Custom body')
+  })
 })

--- a/packages/ui-kit/src/components/ErrorFallback/ErrorFallback.module.scss
+++ b/packages/ui-kit/src/components/ErrorFallback/ErrorFallback.module.scss
@@ -7,12 +7,12 @@
   align-items: center;
   justify-content: center;
   @extend .typographyRegular;
+}
 
-  .container {
-    max-width: 263px;
-    text-align: center;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-  }
+.container {
+  max-width: 263px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }

--- a/packages/ui-kit/src/components/ErrorFallback/ErrorFallback.tsx
+++ b/packages/ui-kit/src/components/ErrorFallback/ErrorFallback.tsx
@@ -27,13 +27,17 @@ const Icon = ({ color }: { color?: string }) => (
 )
 
 export const ErrorFallback = React.forwardRef<HTMLDivElement, ErrorFallbackProps>(
-  ({ error = serverErrorMessage, className, baseTheme, ...rest }, forwardedRef) => {
+  ({ error = serverErrorMessage, className, style, baseTheme, ...rest }, forwardedRef) => {
     const { componentContainer, setRef } = useForwardedRefCallback(forwardedRef)
     useSetupTheme({ componentContainer, baseTheme })
 
     return (
       <div ref={setRef} className={componentStyles.rootErrorFallback} {...rest}>
-        <div className={classnames(componentStyles.container, className)} data-testid="error-fallback-container">
+        <div
+          className={classnames(componentStyles.container, className)}
+          style={{ ...style }}
+          data-testid="error-fallback-container"
+        >
           <Icon />
           {error && (
             <>

--- a/packages/ui-kit/src/components/Leaderboard/Leaderboard.test.tsx
+++ b/packages/ui-kit/src/components/Leaderboard/Leaderboard.test.tsx
@@ -243,4 +243,20 @@ describe('Leaderboard', () => {
 
     await sleep(100)
   })
+
+  it('Should receive errorFallbackProp', () => {
+    dom = render(
+      <Leaderboard
+        errorFallbackProps={{
+          error: {
+            title: 'Custom title',
+            body: 'Custom body'
+          }
+        }}
+      />
+    )
+
+    dom.getByText('Custom title')
+    dom.getByText('Custom body')
+  })
 })

--- a/packages/ui-kit/src/components/Leaderboard/Leaderboard.tsx
+++ b/packages/ui-kit/src/components/Leaderboard/Leaderboard.tsx
@@ -287,7 +287,7 @@ export const LeaderboardComponent = React.forwardRef<HTMLDivElement, Leaderboard
 
     if (hasError || propsMismatch) {
       destroyChart()
-      return <ErrorFallback {...errorFallbackProps} error={error} />
+      return <ErrorFallback error={error} {...errorFallbackProps} />
     }
 
     const isNoContainerRef = (variant === 'bar' && !canvasRef.current) || (variant === 'table' && !innerRef.current)

--- a/packages/ui-kit/src/components/PieChart/PieChart.test.tsx
+++ b/packages/ui-kit/src/components/PieChart/PieChart.test.tsx
@@ -185,4 +185,20 @@ describe('PieChart', () => {
 
     await sleep(100)
   })
+
+  it('Should receive errorFallbackProp', () => {
+    dom = render(
+      <PieChart
+        errorFallbackProps={{
+          error: {
+            title: 'Custom title',
+            body: 'Custom body'
+          }
+        }}
+      />
+    )
+
+    dom.getByText('Custom title')
+    dom.getByText('Custom body')
+  })
 })

--- a/packages/ui-kit/src/components/PieChart/PieChart.tsx
+++ b/packages/ui-kit/src/components/PieChart/PieChart.tsx
@@ -323,7 +323,7 @@ export const PieChartComponent = React.forwardRef<HTMLDivElement, PieChartProps>
 
     if (hasError || propsMismatch) {
       destroyChart()
-      return <ErrorFallback {...errorFallbackProps} error={error} />
+      return <ErrorFallback error={error} {...errorFallbackProps} />
     }
 
     const isNoContainerRef = (variant === 'pie' || variant === 'doughnut') && !canvasRef.current

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.test.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.test.tsx
@@ -144,4 +144,20 @@ describe('TimeSeries', () => {
 
     await sleep(100)
   })
+
+  it('Should receive errorFallbackProp', () => {
+    dom = render(
+      <TimeSeries
+        errorFallbackProps={{
+          error: {
+            title: 'Custom title',
+            body: 'Custom body'
+          }
+        }}
+      />
+    )
+
+    dom.getByText('Custom title')
+    dom.getByText('Custom body')
+  })
 })

--- a/packages/ui-kit/src/components/withContainer/withContainer.tsx
+++ b/packages/ui-kit/src/components/withContainer/withContainer.tsx
@@ -18,10 +18,10 @@ export const withContainer = <P extends object, C extends object>(
         <ErrorBoundary fallback={<ErrorFallback {...errorFallbackProps} />}>
           {componentProps?.card ? (
             <Card style={componentProps?.style} className={componentProps?.className}>
-              <WrappedComponent ref={ref} {...componentProps} />
+              <WrappedComponent ref={ref} {...props} />
             </Card>
           ) : (
-            <WrappedComponent ref={ref} {...componentProps} />
+            <WrappedComponent ref={ref} {...props} />
           )}
         </ErrorBoundary>
       </QueryClientProvider>


### PR DESCRIPTION
## Description of changes

This PR fixes a bug that prevents `errorFallbackProps` from being passed correctly.

## Checklist

Before merging to main:

- [x] Tests
- [x] Manually tested in React apps
- [x] Changesets
- [ ] Approved
