### PR TITLE
PieChart doughnut chart Total value broken when aligning legend right

### DIFF
--- a/.changeset/poor-dancers-explain.md
+++ b/.changeset/poor-dancers-explain.md
@@ -2,4 +2,4 @@
 '@propeldata/ui-kit': patch
 ---
 
-Fixed bug doughnut chart total not aligning correctly
+Fixed bug in doughnut chart, where the total did not align correctly when the legend was rendered on the right.

--- a/.changeset/poor-dancers-explain.md
+++ b/.changeset/poor-dancers-explain.md
@@ -1,0 +1,5 @@
+---
+'@propeldata/ui-kit': patch
+---
+
+Fixed bug doughnut chart total not aligning correctly

--- a/packages/ui-kit/src/components/PieChart/PieChart.stories.tsx
+++ b/packages/ui-kit/src/components/PieChart/PieChart.stories.tsx
@@ -126,6 +126,28 @@ export const DoughnutLegendBottomStory: Story = {
   render: (args) => <PieChart {...args} />
 }
 
+export const DoughnutValuesRightStory: Story = {
+  name: 'Doughnut values right',
+  args: {
+    variant: 'doughnut',
+    query: connectedParams,
+    card: true,
+    chartConfigProps: (config) => ({
+      ...config,
+      options: {
+        ...config.options,
+        plugins: {
+          ...config.plugins,
+          legend: {
+            position: 'right'
+          }
+        }
+      }
+    })
+  },
+  render: (args) => <PieChart {...args} />
+}
+
 export const StaticPieStory: Story = {
   name: 'Static Pie with values',
   args: {

--- a/packages/ui-kit/src/helpers/chartUtils/chartUtils.ts
+++ b/packages/ui-kit/src/helpers/chartUtils/chartUtils.ts
@@ -131,17 +131,18 @@ export const getCustomChartLabelsPlugin = ({
       }
 
       if (datasetMeta.type === 'doughnut' && !hideTotal) {
-        const { ctx } = chart
-
         const totalValue = dataset.data.reduce((a: number, c: number) => a + c, 0).toLocaleString()
 
         ctx.save()
+
         const xCoor = chart.getDatasetMeta(0).data[0].x
         const yCoor = chart.getDatasetMeta(0).data[0].y
+
         ctx.textAlign = 'center'
         ctx.textBaseline = 'middle'
         ctx.font = `12px ${theme?.tinyFontFamily}`
         ctx.fillText('Total', xCoor, yCoor - 12)
+
         ctx.font = `700 24px ${theme?.tinyFontFamily}`
         ctx.fillText(totalValue, xCoor, yCoor + 12)
       }

--- a/packages/ui-kit/src/helpers/chartUtils/chartUtils.ts
+++ b/packages/ui-kit/src/helpers/chartUtils/chartUtils.ts
@@ -131,20 +131,19 @@ export const getCustomChartLabelsPlugin = ({
       }
 
       if (datasetMeta.type === 'doughnut' && !hideTotal) {
-        const totalValue = dataset.data.reduce((a: number, c: number) => a + c, 0).toLocaleString()
-        ctx.font = `12px ${theme?.tinyFontFamily}`
-        ctx.fillText(
-          'Total',
-          chart.width / 2 - ctx.measureText('Total').width / 2,
-          chart.chartArea.height / 2 + chart.chartArea.top - 20
-        )
+        const { ctx } = chart
 
+        const totalValue = dataset.data.reduce((a: number, c: number) => a + c, 0).toLocaleString()
+
+        ctx.save()
+        const xCoor = chart.getDatasetMeta(0).data[0].x
+        const yCoor = chart.getDatasetMeta(0).data[0].y
+        ctx.textAlign = 'center'
+        ctx.textBaseline = 'middle'
+        ctx.font = `12px ${theme?.tinyFontFamily}`
+        ctx.fillText('Total', xCoor, yCoor - 12)
         ctx.font = `700 24px ${theme?.tinyFontFamily}`
-        ctx.fillText(
-          totalValue,
-          chart.width / 2 - ctx.measureText(totalValue).width / 2,
-          chart.chartArea.height / 2 + chart.chartArea.top + 5
-        )
+        ctx.fillText(totalValue, xCoor, yCoor + 12)
       }
     }
   }


### PR DESCRIPTION
## Description of changes

This PR fixes a bug with the `Total` value of the doughnut chart that is not correctly aligned when changing the position of the legends
![image](https://github.com/propeldata/ui-kit/assets/84721399/56c1cae0-a435-4aa4-98df-dc2f71784668)

In order to do this I changed the approach to draw the total based on the x and y coordinates of the center using the chart.js api, this is a popular approach for doing this and comes from this [tutorial](https://www.youtube.com/watch?v=c2mzQKpd_DI)

## Checklist

Before merging to main:

- [ ] Tests
- [x] Manually tested in React apps
- [x] Changesets
- [x] Approved
