### PR TITLE
fix(pie-chart): adjust padding for hover state

### DIFF
--- a/.changeset/hip-parents-travel.md
+++ b/.changeset/hip-parents-travel.md
@@ -1,0 +1,5 @@
+---
+'@propeldata/ui-kit': patch
+---
+
+[PieChart] Fix chart rendering when Total is hidden

--- a/packages/ui-kit/src/components/PieChart/PieChart.tsx
+++ b/packages/ui-kit/src/components/PieChart/PieChart.tsx
@@ -204,7 +204,7 @@ export const PieChartComponent = React.forwardRef<HTMLDivElement, PieChartProps>
             responsive: true,
             maintainAspectRatio: false,
             layout: {
-              padding: 4
+              padding: 10
             },
             plugins: {
               ...chartConfig.options?.plugins,


### PR DESCRIPTION
## Description of changes

This PR resolves [PieChart gets cut off](https://linear.app/propel/issue/PRO-2767/piechart-gets-cut-off)

| Before | After |
| --- | --- |
| ![pichart_cut](https://github.com/propeldata/ui-kit/assets/55801864/fb35618a-fd3f-43b9-bb65-c5c56b3d358f) | ![piechart_cut_after](https://github.com/propeldata/ui-kit/assets/55801864/cd724f39-48b4-47dc-b671-bb54b83efa80) |

## Checklist

Before merging to main:

- [ ] Tests
- [x] Manually tested in React apps
- [x] Changesets
- [ ] Approved
