### PR TITLE
Enable setting TimeSeries accentColor via `accentColors` prop

### DIFF
--- a/.changeset/fair-waves-lick.md
+++ b/.changeset/fair-waves-lick.md
@@ -1,0 +1,5 @@
+---
+'@propeldata/ui-kit': patch
+---
+
+Deprecated `accentColor` in favor of `accentColors`

--- a/packages/ui-kit/src/components/PieChart/PieChart.tsx
+++ b/packages/ui-kit/src/components/PieChart/PieChart.tsx
@@ -61,7 +61,10 @@ export const PieChartComponent = React.forwardRef<HTMLDivElement, PieChartProps>
     }: PieChartProps,
     forwardedRef: React.ForwardedRef<HTMLDivElement>
   ) => {
-    const { themeSettings, parsedProps } = useParsedComponentProps(rest)
+    const { themeSettings, parsedProps } = useParsedComponentProps({
+      ...rest,
+      accentColor: (accentColors?.[0] as AccentColors) ?? rest.accentColor
+    })
     const innerRef = React.useRef<HTMLDivElement>(null)
     const { componentContainer, setRef } = useCombinedRefsCallback({ innerRef, forwardedRef })
     const themeWrapper = withThemeWrapper(setRef)

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.stories.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.stories.tsx
@@ -95,7 +95,8 @@ export const LineStory: Story = {
   args: {
     variant: 'line',
     query: connectedParams,
-    card: true
+    card: true,
+    accentColors: ['#ff0000']
   },
   render: (args) => <TimeSeries {...args} />
 }

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
@@ -17,7 +17,7 @@ import {
   withThemeWrapper
 } from '../../helpers'
 import { useTimeSeries } from '../../hooks'
-import { useParsedComponentProps } from '../../themes'
+import { AccentColors, useParsedComponentProps } from '../../themes'
 import { ErrorFallback, ErrorFallbackProps } from '../ErrorFallback'
 import { useFilters } from '../FilterProvider'
 import { Loader, LoaderProps } from '../Loader'
@@ -85,7 +85,10 @@ export const TimeSeriesComponent = React.forwardRef<HTMLDivElement, TimeSeriesPr
     },
     forwardedRef
   ) => {
-    const { themeSettings, parsedProps } = useParsedComponentProps(rest)
+    const { themeSettings, parsedProps } = useParsedComponentProps({
+      ...rest,
+      accentColor: (accentColors[0] as AccentColors) ?? rest.accentColor
+    })
     const { componentContainer, setRef } = useForwardedRefCallback(forwardedRef)
     const themeWrapper = withThemeWrapper(setRef)
     const type = variant === 'line' ? ('shadowLine' as TimeSeriesChartVariant) : 'bar'

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.types.ts
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.types.ts
@@ -38,7 +38,7 @@ export interface TimeSeriesChartProps {
   fillArea?: boolean
 }
 
-export interface TimeSeriesBaseProps extends ThemeSettingProps, DataComponentProps<'div'> {
+export interface TimeSeriesBaseProps extends Omit<ThemeSettingProps, 'accentColor'>, DataComponentProps<'div'> {
   /** @deprecated This type is deprecated, use `errorFallbackProps` and `errorFallback` instead */
   error?: {
     title: string
@@ -86,6 +86,13 @@ export interface TimeSeriesBaseProps extends ThemeSettingProps, DataComponentPro
 
   /** Color that will be used for the `other` dataset when using groupBy */
   otherColor?: GrayColors | string
+
+  /**
+   * The global theme accent color. This color is used to highlight elements
+   *
+   * @deprecated - This prop is deprecated and will be removed in a future release. Use `accentColors` prop instead.
+   */
+  accentColor?: AccentColors
 }
 
 export interface TimeSeriesLineProps extends TimeSeriesBaseProps {

--- a/packages/ui-kit/src/components/TimeSeries/utils.ts
+++ b/packages/ui-kit/src/components/TimeSeries/utils.ts
@@ -12,7 +12,8 @@ import {
   palette,
   PaletteColor,
   grayColors,
-  handleArbitraryColor
+  handleArbitraryColor,
+  accentColors as accentColorsDict
 } from '../../themes'
 import { Maybe, RelativeTimeRange, TimeRangeInput, TimeSeriesGranularity } from '../../graphql'
 import { getDisplayValue, getPixelFontSizeAsNumber } from '../../helpers'
@@ -342,24 +343,34 @@ export function buildDatasets(
     getPixelFontSizeAsNumber(theme?.getVar('--propel-radius-full'))
   )
 
+  const accentColor = accentColors[0] ?? theme.accentColor
+
+  const mainColor = {
+    name: accentColor,
+    primary: accentColorsDict.includes(accentColor as AccentColors)
+      ? theme?.getVar('--propel-accent-8')
+      : handleArbitraryColor(accentColor),
+    secondary: accentColorsDict.includes(accentColor as AccentColors)
+      ? theme?.getVar('--propel-accent-10')
+      : handleArbitraryColor(accentColor)
+  }
+
   if (groups == null || groups.length === 0) {
     return [
       {
         data: getNumericValues(values ?? [], log),
-        backgroundColor: theme?.getVar('--propel-accent-8'),
-        borderColor: theme?.getVar('--propel-accent-8'),
+        backgroundColor: mainColor.primary,
+        borderColor: mainColor.primary,
         borderRadius,
-        hoverBackgroundColor: theme?.getVar('--propel-accent-10'),
-        pointBackgroundColor: theme?.getVar('--propel-accent-10'),
-        pointHoverBackgroundColor: theme?.getVar('--propel-accent-10'),
+        hoverBackgroundColor: mainColor.secondary,
+        pointBackgroundColor: mainColor.secondary,
+        pointHoverBackgroundColor: mainColor.secondary,
         pointHoverBorderWidth: 2,
         pointHoverBorderColor: theme?.getVar('--propel-accent-contrast'),
         fill
       } as ChartDataset<TimeSeriesChartVariant>
     ]
   }
-
-  const accentColor = accentColors[0] ?? theme.accentColor
 
   const isArbitraryGray = otherColor != null && !grayColors.includes(otherColor as GrayColors)
   const grayColor: PaletteColor = {

--- a/packages/ui-kit/src/themes/helpers/useParsedComponentProps.ts
+++ b/packages/ui-kit/src/themes/helpers/useParsedComponentProps.ts
@@ -1,6 +1,6 @@
 import { useCallback, useContext } from 'react'
 import { ThemeContext } from '../../components/ThemeProvider'
-import { AccentColors, GrayColors, ThemeSettingProps } from '../theme.types'
+import { accentColors, AccentColors, GrayColors, ThemeSettingProps } from '../theme.types'
 import { getMatchingGrayColor } from './getMatchingGrayColor'
 
 export const useParsedComponentProps = ({
@@ -21,7 +21,8 @@ export const useParsedComponentProps = ({
     [context]
   )
 
-  const accentColor = accentColorProp ? accentColorProp : (getDefault('blue') as AccentColors)
+  const accentColor =
+    accentColorProp && accentColors.includes(accentColorProp) ? accentColorProp : (getDefault('blue') as AccentColors)
   const grayColorVal = grayColorProp ? grayColorProp : (getDefault('auto') as GrayColors)
   const grayColor = grayColorVal === 'auto' ? getMatchingGrayColor(accentColor ?? 'blue') : grayColorVal
 


### PR DESCRIPTION
## Description of changes

This PR deprecates `accentColor` prop in favor of `accentColors`

## Checklist

Before merging to main:

- [ ] Tests
- [ ] Manually tested in React apps
- [x] Changesets
- [ ] Approved
