### PR TITLE
Fix chartConfigProps incorrect type for TimeSeries

### DIFF
--- a/.changeset/modern-tomatoes-drum.md
+++ b/.changeset/modern-tomatoes-drum.md
@@ -1,0 +1,5 @@
+---
+'@propeldata/ui-kit': patch
+---
+
+Fix chartConfigProps type definition for TimeSeries

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.stories.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.stories.tsx
@@ -71,17 +71,18 @@ const connectedParams: TimeSeriesQueryProps = {
 const TimeSeries = (args: Story['args']) => {
   const { accessToken } = useStorybookAccessToken(axiosInstance)
 
-  if (!accessToken && args?.query) {
+  if (args == null || (!accessToken && args?.query)) {
     return null
   }
 
   return (
+    // @ts-expect-error storybook types are not correct
     <TimeSeriesSource
       {...{
         ...args,
-        query: args?.query
+        query: args.query
           ? {
-              ...args?.query,
+              ...args.query,
               accessToken
             }
           : undefined

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
@@ -25,7 +25,7 @@ import { useLog } from '../Log'
 import { useSetupTheme } from '../ThemeProvider'
 import { withContainer } from '../withContainer'
 import componentStyles from './TimeSeries.module.scss'
-import type { TimeSeriesChartVariant, TimeSeriesData, TimeSeriesProps } from './TimeSeries.types'
+import { DEFAULT_VARIANT, TimeSeriesChartVariant, TimeSeriesData, TimeSeriesProps } from './TimeSeries.types'
 import { buildDatasets, getDefaultGranularity, getScales, tooltipTitleCallback } from './utils'
 
 let idCounter = 0
@@ -57,7 +57,7 @@ ChartJS.register(CustomLineController)
 export const TimeSeriesComponent = React.forwardRef<HTMLDivElement, TimeSeriesProps>(
   (
     {
-      variant = 'bar',
+      variant = DEFAULT_VARIANT,
       labels,
       values,
       query,

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.types.ts
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.types.ts
@@ -5,6 +5,8 @@ import { TimeSeriesLabels } from '../../helpers'
 import { AccentColors, GrayColors, ThemeSettingProps } from '../../themes'
 import type { DataComponentProps, QueryProps } from '../shared.types'
 
+export const DEFAULT_VARIANT = 'bar'
+
 export type ChartScales = DeepPartial<{ [key: string]: ScaleOptionsByType<'linear' | 'logarithmic'> }>
 
 export type TimeSeriesChartVariant = 'bar' | 'line'
@@ -94,15 +96,22 @@ export interface TimeSeriesBaseProps extends Omit<ThemeSettingProps, 'accentColo
    */
   accentColor?: AccentColors
 }
+export interface TimeSeriesDefaultVariantProps extends TimeSeriesBaseProps {
+  variant?: undefined
+  chartConfigProps?: (config: ChartConfiguration<typeof DEFAULT_VARIANT>) => ChartConfiguration<typeof DEFAULT_VARIANT>
+}
 
 export interface TimeSeriesLineProps extends TimeSeriesBaseProps {
-  variant?: 'line'
+  variant: 'line'
   chartConfigProps?: (config: ChartConfiguration<'line'>) => ChartConfiguration<'line'>
 }
 
 export interface TimeSeriesBarProps extends TimeSeriesBaseProps {
-  variant?: 'bar'
+  variant: 'bar'
   chartConfigProps?: (config: ChartConfiguration<'bar'>) => ChartConfiguration<'bar'>
 }
 
-export type TimeSeriesProps = TimeSeriesLineProps | TimeSeriesBarProps
+export type TimeSeriesProps =
+  | (TimeSeriesDefaultVariantProps & { variant?: undefined })
+  | TimeSeriesLineProps
+  | TimeSeriesBarProps


### PR DESCRIPTION
## Description of changes

This PR fixes `chartConfigProps` type for TimeSeries 

## Checklist

Before merging to main:

- [ ] Tests
- [ ] Manually tested in React apps
- [ ] Changesets
- [ ] Approved
