### PR TITLE
`defaultOpen` prop

### DIFF
--- a/.changeset/rotten-steaks-joke.md
+++ b/.changeset/rotten-steaks-joke.md
@@ -1,0 +1,5 @@
+---
+'@propeldata/ui-kit': patch
+---
+
+Added `defaultOpen` prop

--- a/packages/ui-kit/src/components/Autocomplete/Autocomplete.tsx
+++ b/packages/ui-kit/src/components/Autocomplete/Autocomplete.tsx
@@ -34,6 +34,7 @@ export const Autocomplete = React.forwardRef(function Autocomplete(
     listClassname,
     optionStyle,
     optionClassname,
+    defaultOpen = false,
     disableClearable = false,
     ...rest
   } = props
@@ -41,6 +42,8 @@ export const Autocomplete = React.forwardRef(function Autocomplete(
   const inputContainerRef = React.useRef<HTMLDivElement>(null)
 
   const { themeSettings, parsedPropsWithoutRest } = useParsedComponentProps(props)
+
+  const [isOpen, setIsOpen] = React.useState(defaultOpen)
 
   const {
     getRootProps,
@@ -55,7 +58,8 @@ export const Autocomplete = React.forwardRef(function Autocomplete(
     anchorEl,
     setAnchorEl,
     groupedOptions,
-    getClearProps
+    getClearProps,
+    value
   } = useAutocomplete({
     ...props,
     componentName: 'Autocomplete',
@@ -73,8 +77,15 @@ export const Autocomplete = React.forwardRef(function Autocomplete(
       }
       return ''
     },
-    blurOnSelect: true
+    blurOnSelect: true,
+    open: isOpen
   })
+
+  React.useEffect(() => {
+    if (value) {
+      setIsOpen(false)
+    }
+  }, [value])
 
   const { componentContainer, setRef } = useForwardedRefCallback(ref)
 
@@ -114,6 +125,12 @@ export const Autocomplete = React.forwardRef(function Autocomplete(
               style: {
                 ...getInputProps().style,
                 ...inputStyle
+              },
+              onFocus: () => {
+                setIsOpen(true)
+              },
+              onBlur: () => {
+                setIsOpen(false)
               }
             }
           }}
@@ -139,6 +156,9 @@ export const Autocomplete = React.forwardRef(function Autocomplete(
           open={popupOpen}
           anchorEl={anchorEl}
           placement="bottom-start"
+          popperOptions={{
+            strategy: 'fixed'
+          }}
           slots={{
             root: 'div'
           }}

--- a/packages/ui-kit/src/components/Autocomplete/Autocomplete.types.ts
+++ b/packages/ui-kit/src/components/Autocomplete/Autocomplete.types.ts
@@ -42,4 +42,7 @@ export interface AutocompleteProps
 
   /** If true, enables the user to type an arbitrary value */
   freeSolo?: boolean
+
+  /** If true, the dropdown will be open by default */
+  defaultOpen?: boolean
 }

--- a/packages/ui-kit/src/components/GroupBy/GroupBy.types.ts
+++ b/packages/ui-kit/src/components/GroupBy/GroupBy.types.ts
@@ -39,4 +39,7 @@ export interface GroupByProps
 
   /** Maximum number of group by columns */
   maxGroupBy?: number
+
+  /** If true, the dropdown will be open by default */
+  defaultOpen?: boolean
 }

--- a/packages/ui-kit/src/components/SimpleFilter/SimpleFilter.tsx
+++ b/packages/ui-kit/src/components/SimpleFilter/SimpleFilter.tsx
@@ -24,6 +24,7 @@ const SimpleFilterComponent = React.forwardRef<HTMLSpanElement, SimpleFilterProp
       loading,
       loaderProps: loaderPropsInitial,
       renderLoader,
+      defaultOpen = false,
       options = []
     },
     forwardedRef
@@ -96,6 +97,7 @@ const SimpleFilterComponent = React.forwardRef<HTMLSpanElement, SimpleFilterProp
         {...autocompleteProps}
         options={autocompleteOptions}
         onChange={handleChange}
+        defaultOpen={defaultOpen}
         freeSolo={isError || autocompleteProps?.freeSolo}
       />
     )

--- a/packages/ui-kit/src/components/SimpleFilter/SimpleFilter.types.ts
+++ b/packages/ui-kit/src/components/SimpleFilter/SimpleFilter.types.ts
@@ -34,4 +34,7 @@ export interface SimpleFilterProps
 
   /** Whether there was an error or not, setting to `true` will enable freeSolo mode */
   error?: boolean
+
+  /** If true, the dropdown will be open by default */
+  defaultOpen?: boolean
 }

--- a/packages/ui-kit/src/components/TimeGrainPicker/TimeGrainPicker.stories.tsx
+++ b/packages/ui-kit/src/components/TimeGrainPicker/TimeGrainPicker.stories.tsx
@@ -51,7 +51,8 @@ export const SingleStory: Story = {
   args: {
     selectProps: {
       placeholder: 'Granularity'
-    }
+    },
+    defaultOpen: true
   },
   render: (args) => (
     <FilterProvider>

--- a/packages/ui-kit/src/components/TimeGrainPicker/TimeGrainPicker.tsx
+++ b/packages/ui-kit/src/components/TimeGrainPicker/TimeGrainPicker.tsx
@@ -15,7 +15,7 @@ interface TimeGrainPickerOption {
 }
 
 export const TimeGrainPicker = React.forwardRef<HTMLDivElement, TimeGrainPickerProps>(
-  ({ selectProps, options = OrderedTimeSeriesGranularity, ...rest }, forwardedRef) => {
+  ({ selectProps, options = OrderedTimeSeriesGranularity, defaultOpen = false, ...rest }, forwardedRef) => {
     const selectOptions = React.useMemo(
       () => options.map((option) => ({ label: granularityLabel[option], value: option })),
       [options]
@@ -37,6 +37,7 @@ export const TimeGrainPicker = React.forwardRef<HTMLDivElement, TimeGrainPickerP
         <Select
           {...selectProps}
           ref={selectRef}
+          defaultOpen={defaultOpen}
           onChange={(_, optionValue) => {
             if (optionValue == null) {
               return

--- a/packages/ui-kit/src/components/TimeGrainPicker/TimeGrainPicker.types.ts
+++ b/packages/ui-kit/src/components/TimeGrainPicker/TimeGrainPicker.types.ts
@@ -14,6 +14,9 @@ export interface TimeGrainPickerProps
 
   /** Whether there was an error or not, setting to `true` will enable freeSolo mode */
   error?: boolean
+
+  /** If true, the select is open by default. */
+  defaultOpen?: boolean
 }
 
 export const OrderedTimeSeriesGranularity = [

--- a/packages/ui-kit/src/components/TimeRangePicker/TimeRangePicker.tsx
+++ b/packages/ui-kit/src/components/TimeRangePicker/TimeRangePicker.tsx
@@ -58,6 +58,7 @@ export const TimeRangePicker = React.forwardRef<HTMLDivElement, TimeRangePickerP
       size = 'default',
       value,
       onChange,
+      defaultOpen = false,
       ...rest
     },
     forwardedRef
@@ -326,6 +327,7 @@ export const TimeRangePicker = React.forwardRef<HTMLDivElement, TimeRangePickerP
           startAdornment={() => <CalendarIcon size={16} />}
           value={selectedOption}
           placeholder="Date Range"
+          defaultOpen={defaultOpen}
           onListboxOpenChange={(listboxOpen) => {
             if (!popupOpen) {
               setSelectOpen(listboxOpen)

--- a/packages/ui-kit/src/components/TimeRangePicker/TimeRangePicker.types.ts
+++ b/packages/ui-kit/src/components/TimeRangePicker/TimeRangePicker.types.ts
@@ -2,7 +2,7 @@ import type { TimeRangeInput } from '../../graphql'
 import { ThemeSettingProps } from '../../themes'
 import type { ButtonProps } from '../Button'
 
-export type DateRangeOptionsProps = {
+export interface DateRangeOptionsProps {
   /** A unique identifier for the date range option, used to distinguish between different options. */
   value: string
 
@@ -46,4 +46,7 @@ export interface TimeRangePickerProps
 
   /** A callback function that is fired when the selected value changes, providing the new value as an argument. */
   onChange?: (option: DateRangeOptionsProps) => void
+
+  /** If true, the select is open by default. */
+  defaultOpen?: boolean
 }


### PR DESCRIPTION
## Description of changes

This PR adds `defaultOpen` to `TimeGrainPicker`, `TimeRangePicker`, `SimpleFilter` and `GroupBy` components besides of the base `Select` and `Autocomplete`

## Checklist

Before merging to main:

- [ ] Tests
- [ ] Manually tested in React apps
- [ ] Changesets
- [ ] Approved
