### PR TITLE
TimeSeries `groupByColors` prop

### DIFF
--- a/.changeset/tall-mirrors-speak.md
+++ b/.changeset/tall-mirrors-speak.md
@@ -1,0 +1,6 @@
+---
+'@propeldata/ui-kit': patch
+---
+
+- Remove `accentColor` deprecated tag for TimeSeries
+- Rename `accentColors` to `groupByColors` and deprecate `accentColors`

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.stories.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.stories.tsx
@@ -98,7 +98,7 @@ export const LineStory: Story = {
     variant: 'line',
     query: connectedParams,
     card: true,
-    accentColors: ['#ff0000']
+    groupByColors: ['#ff0000']
   },
   render: (args) => <TimeSeries {...args} />
 }
@@ -309,7 +309,7 @@ export const GroupedStory: Story = {
     showGroupByOther: true,
     maxGroupBy: 5,
     stacked: true,
-    accentColors: ['red', 'blue'],
+    groupByColors: ['red', 'blue'],
     card: true,
     otherColor: 'gray'
   },

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.tsx
@@ -80,6 +80,7 @@ export const TimeSeriesComponent = React.forwardRef<HTMLDivElement, TimeSeriesPr
       maxGroupBy: maxGroupByProp,
       showGroupByOther = true,
       accentColors = [],
+      groupByColors = [],
       stacked = false,
       otherColor,
       ...rest
@@ -88,7 +89,7 @@ export const TimeSeriesComponent = React.forwardRef<HTMLDivElement, TimeSeriesPr
   ) => {
     const { themeSettings, parsedProps } = useParsedComponentProps({
       ...rest,
-      accentColor: (accentColors[0] as AccentColors) ?? rest.accentColor
+      accentColor: (groupByColors[0] as AccentColors) ?? (accentColors[0] as AccentColors) ?? rest.accentColor
     })
     const { componentContainer, setRef } = useForwardedRefCallback(forwardedRef)
     const themeWrapper = withThemeWrapper(setRef)
@@ -207,7 +208,7 @@ export const TimeSeriesComponent = React.forwardRef<HTMLDivElement, TimeSeriesPr
         const datasets = buildDatasets(
           data,
           theme,
-          { fill, maxGroupBy, showGroupByOther, accentColors, otherColor },
+          { fill, maxGroupBy, showGroupByOther, groupByColors: groupByColors ?? accentColors, otherColor },
           log
         )
 
@@ -278,6 +279,7 @@ export const TimeSeriesComponent = React.forwardRef<HTMLDivElement, TimeSeriesPr
         variant,
         maxGroupBy,
         showGroupByOther,
+        groupByColors,
         accentColors,
         otherColor,
         log,

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.types.ts
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.types.ts
@@ -40,7 +40,7 @@ export interface TimeSeriesChartProps {
   fillArea?: boolean
 }
 
-export interface TimeSeriesBaseProps extends Omit<ThemeSettingProps, 'accentColor'>, DataComponentProps<'div'> {
+export interface TimeSeriesBaseProps extends ThemeSettingProps, DataComponentProps<'div'> {
   /** @deprecated This type is deprecated, use `errorFallbackProps` and `errorFallback` instead */
   error?: {
     title: string
@@ -80,21 +80,17 @@ export interface TimeSeriesBaseProps extends Omit<ThemeSettingProps, 'accentColo
   /** If true, an `other` dataset will be shown */
   showGroupByOther?: boolean
 
-  /** A list of accent colors the TimeSeries component will use to show groups, those will be picked in order */
+  /** @deprecated - A list of accent colors the TimeSeries component will use to show groups, those will be picked in order, this prop is deprecated and will be removed in a future release. Use `groupByColors` instead. */
   accentColors?: (AccentColors | string)[]
+
+  /** A list of accent colors the TimeSeries component will use to show groups, those will be picked in order */
+  groupByColors?: (AccentColors | string)[]
 
   /** If true, chart's lines or bars will be stacked */
   stacked?: boolean
 
   /** Color that will be used for the `other` dataset when using groupBy */
   otherColor?: GrayColors | string
-
-  /**
-   * The global theme accent color. This color is used to highlight elements
-   *
-   * @deprecated - This prop is deprecated and will be removed in a future release. Use `accentColors` prop instead.
-   */
-  accentColor?: AccentColors
 }
 export interface TimeSeriesDefaultVariantProps extends TimeSeriesBaseProps {
   variant?: undefined

--- a/packages/ui-kit/src/components/TimeSeries/utils.ts
+++ b/packages/ui-kit/src/components/TimeSeries/utils.ts
@@ -324,7 +324,7 @@ interface BuildDatasetsOptions {
   fill?: boolean
   maxGroupBy: number
   showGroupByOther: boolean
-  accentColors: (AccentColors | string)[]
+  groupByColors: (AccentColors | string)[]
   otherColor?: GrayColors | string
 }
 
@@ -336,14 +336,14 @@ export function buildDatasets(
 ): ChartDataset<TimeSeriesChartVariant>[] {
   const { values, groups } = data
 
-  const { fill = false, maxGroupBy, showGroupByOther, accentColors, otherColor } = options ?? {}
+  const { fill = false, maxGroupBy, showGroupByOther, groupByColors, otherColor } = options ?? {}
 
   const borderRadius = Math.max(
     getPixelFontSizeAsNumber(theme?.getVar('--propel-radius-2')),
     getPixelFontSizeAsNumber(theme?.getVar('--propel-radius-full'))
   )
 
-  const accentColor = accentColors[0] ?? theme.accentColor
+  const accentColor = groupByColors[0] ?? theme.accentColor
 
   const mainColor = {
     name: accentColor,
@@ -383,14 +383,14 @@ export function buildDatasets(
       : theme.tokens[`${otherColor ?? theme.grayColor}10`] ?? radixColors.gray.gray10
   }
 
-  const isCustomColors = accentColors.length > 0
+  const isCustomColors = groupByColors.length > 0
 
   let customColors: (PaletteColor | undefined)[] = []
 
   let colorPos = palette.findIndex((value) => value?.name === accentColor)
 
   if (isCustomColors) {
-    customColors = accentColors.map(
+    customColors = groupByColors.map(
       (color) =>
         palette.find(({ name }) => name === color) ?? {
           primary: handleArbitraryColor(color),


### PR DESCRIPTION
## Description of changes

This PR adds a `groupByColors` prop to TimeSeries that replaces `accentColors` and remove deprecated tag for `accentColor`

## Checklist

Before merging to main:

- [ ] Tests
- [ ] Manually tested in React apps
- [ ] Changesets
- [ ] Approved
