### PR TITLE
Deprecate `filters` and add `filterSql`

### DIFF
--- a/.changeset/proud-cows-hope.md
+++ b/.changeset/proud-cows-hope.md
@@ -1,0 +1,5 @@
+---
+'@propeldata/ui-kit': minor
+---
+
+Prefer filterSql and deprecate filters

--- a/packages/ui-kit/src/components/FilterProvider/FilterProvider.stories.tsx
+++ b/packages/ui-kit/src/components/FilterProvider/FilterProvider.stories.tsx
@@ -80,3 +80,25 @@ export const PieChartGroupBy: Story = {
     </TokenProvider>
   )
 }
+
+export const FilterSql: Story = {
+  name: 'FilterSql',
+  render: (args) => (
+    <TokenProvider>
+      <FilterProvider
+        {...args}
+        defaultDataPool={{ name: 'TacoSoft Demo Data' }}
+        baseFilterSql="taco_name = 'Veggie' AND sauce_name = 'Queso Blanco'"
+      >
+        <SimpleFilter query={{ columnName: 'taco_name' }} />
+        <SimpleFilter query={{ columnName: 'sauce_name' }} />
+        <TimeRangePicker />
+        <Counter query={{ metric: { count: {} } }} />
+        <TimeSeries query={{ metric: { count: {} } }} />
+        <Leaderboard query={{ metric: { count: {} }, dimensions: [{ columnName: 'taco_name' }] }} />
+        <DataGrid />
+        <PieChart query={{ metric: { count: {} } }} />
+      </FilterProvider>
+    </TokenProvider>
+  )
+}

--- a/packages/ui-kit/src/components/FilterProvider/FilterProvider.test.tsx
+++ b/packages/ui-kit/src/components/FilterProvider/FilterProvider.test.tsx
@@ -1,20 +1,16 @@
 import React from 'react'
 import { fireEvent, render } from '@testing-library/react'
 
-import { Dom, FilterInput, FilterOperator, mockCounterQuery, RelativeTimeRange, setupTestHandlers } from '../../testing'
+import { Dom, mockCounterQuery, RelativeTimeRange, setupTestHandlers } from '../../testing'
 import { FilterProvider } from './FilterProvider'
 import { SimpleFilter } from '../SimpleFilter'
 import { Counter } from '../Counter'
 
 const handlers = [
   mockCounterQuery((req, res, ctx) => {
-    const filters: FilterInput[] = req.variables.counterInput.filters
+    const filterSql: string = req.variables.counterInput.filterSql
 
-    if (
-      filters[0].column === 'test-column' &&
-      filters[0].operator === FilterOperator.Equals &&
-      filters[0].value === 'option'
-    ) {
+    if (filterSql === `"test-column" = 'option'`) {
       return res(ctx.data({ counter: { value: 200 } }))
     }
 

--- a/packages/ui-kit/src/components/FilterProvider/FilterProvider.tsx
+++ b/packages/ui-kit/src/components/FilterProvider/FilterProvider.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { createContext, useState } from 'react'
+import React, { createContext, useEffect, useState } from 'react'
 import { DataPoolInput, TimeRangeInput, TimeSeriesGranularity } from '../../graphql'
 
 import { FilterContextProps, FilterContextValue, FilterInputWithId } from './FilterProvider.types'
@@ -17,7 +17,11 @@ export const FilterContext = createContext<FilterContextValue>({
   emptyGroupBy: [],
   maxGroupBy: undefined,
   dataPool: null,
-  setDataPool: () => {}
+  setDataPool: () => {},
+  filterSql: null,
+  setFilterSql: () => {},
+  filterSqlList: [],
+  setFilterSqlList: () => {}
 })
 
 export const FilterProvider: React.FC<React.PropsWithChildren<FilterContextProps>> = ({
@@ -28,7 +32,8 @@ export const FilterProvider: React.FC<React.PropsWithChildren<FilterContextProps
   emptyGroupBy = [],
   maxGroupBy,
   defaultTimeRange,
-  defaultDataPool
+  defaultDataPool,
+  baseFilterSql
 }) => {
   const [filters, setFilters] = useState<FilterInputWithId[]>(
     baseFilters?.map((filter) => ({ ...filter, id: Symbol() })) ?? []
@@ -37,6 +42,17 @@ export const FilterProvider: React.FC<React.PropsWithChildren<FilterContextProps
   const [granularity, setGranularity] = useState<TimeSeriesGranularity>(defaultGranularity)
   const [groupBy, setGroupBy] = useState<string[]>(defaultGroupBy)
   const [dataPool, setDataPool] = useState<DataPoolInput | null | undefined>(defaultDataPool)
+  const [filterSql, setFilterSql] = useState<string | null | undefined>(baseFilterSql)
+
+  const [filterSqlList, setFilterSqlList] = useState<Array<{ filterSql: string; id: symbol }>>([])
+
+  useEffect(() => {
+    if (filterSqlList.length > 0) {
+      setFilterSql(filterSqlList.map(({ filterSql }) => filterSql).join(' AND '))
+    } else {
+      setFilterSql(baseFilterSql)
+    }
+  }, [baseFilterSql, filterSql, filterSqlList])
 
   return (
     <FilterContext.Provider
@@ -52,7 +68,11 @@ export const FilterProvider: React.FC<React.PropsWithChildren<FilterContextProps
         emptyGroupBy,
         maxGroupBy,
         dataPool,
-        setDataPool
+        setDataPool,
+        filterSql,
+        setFilterSql,
+        filterSqlList,
+        setFilterSqlList
       }}
     >
       {children}

--- a/packages/ui-kit/src/components/FilterProvider/FilterProvider.types.ts
+++ b/packages/ui-kit/src/components/FilterProvider/FilterProvider.types.ts
@@ -5,10 +5,18 @@ export interface FilterInputWithId extends FilterInput {
 }
 
 export interface FilterContextValue {
-  /** Filters that will be provided to the child components */
+  /** @deprecated use filterSql instead */
   filters: FilterInputWithId[]
-  /** Setter function for the Filters */
+  /** @deprecated use filterSql instead */
   setFilters: React.Dispatch<React.SetStateAction<FilterInputWithId[]>>
+  /** SQL Filter that will be provided to the child components */
+  filterSql: string | null | undefined
+  /** Setter function for the SQL Filter */
+  setFilterSql: React.Dispatch<React.SetStateAction<string | null | undefined>>
+  /** List of filters, those will be merged into the filterSql using AND operator */
+  filterSqlList: Array<{ filterSql: string; id: symbol }>
+  /** Setter function for the SQL Filter List */
+  setFilterSqlList: React.Dispatch<React.SetStateAction<Array<{ filterSql: string; id: symbol }>>>
   /** Timerange that will be provided to the child components */
   timeRange: TimeRangeInput | null | undefined
   /** Setter function for the Time Range */
@@ -34,6 +42,8 @@ export interface FilterContextValue {
 export interface FilterContextProps {
   /** Set of pre defined filters that will be used by all the child components */
   baseFilters?: FilterInput[]
+  /** SQL Filter that will be used by all the child components */
+  baseFilterSql?: string
   /** Default time granularity */
   defaultGranularity?: TimeSeriesGranularity
   /** Default group by */

--- a/packages/ui-kit/src/components/SimpleFilter/SimpleFilter.test.tsx
+++ b/packages/ui-kit/src/components/SimpleFilter/SimpleFilter.test.tsx
@@ -2,16 +2,19 @@ import React from 'react'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 
 import { FilterProvider } from '../FilterProvider'
-import { Dom, FilterOperator, mockTopValuesQuery, RelativeTimeRange, setupTestHandlers } from '../../testing'
+import { Dom, mockTopValuesQuery, RelativeTimeRange, setupTestHandlers } from '../../testing'
 
 import { SimpleFilter } from './SimpleFilter'
 
 const setFilterMock = jest.fn()
+const setFilterSqlListMock = jest.fn()
 
 jest.mock('../FilterProvider/useFilters', () => ({
   useFilters: () => ({
     filters: [],
-    setFilters: setFilterMock
+    setFilters: setFilterMock,
+    filterSqlList: [],
+    setFilterSqlList: setFilterSqlListMock
   })
 }))
 
@@ -66,12 +69,10 @@ describe('SimpleFilter', () => {
     fireEvent.click(dom.getByRole('button', { name: 'dropdown-button' }))
     fireEvent.click(dom.getByText('option 1'))
 
-    expect(setFilterMock).toHaveBeenCalledWith([
+    expect(setFilterSqlListMock).toHaveBeenCalledWith([
       {
         id: expect.any(Symbol),
-        column: 'test column',
-        operator: FilterOperator.Equals,
-        value: 'option 1'
+        filterSql: `"test column" = 'option 1'`
       }
     ])
   })
@@ -101,12 +102,10 @@ describe('SimpleFilter', () => {
       fireEvent.click(dom.getByText('option 1'))
     })
 
-    expect(setFilterMock).toHaveBeenCalledWith([
+    expect(setFilterSqlListMock).toHaveBeenCalledWith([
       {
         id: expect.any(Symbol),
-        column: 'test column',
-        operator: FilterOperator.Equals,
-        value: 'option 1'
+        filterSql: `"test column" = 'option 1'`
       }
     ])
   })
@@ -137,12 +136,10 @@ describe('SimpleFilter', () => {
       fireEvent.click(dom.getByText('Europe/Berlin'))
     })
 
-    expect(setFilterMock).toHaveBeenCalledWith([
+    expect(setFilterSqlListMock).toHaveBeenCalledWith([
       {
         id: expect.any(Symbol),
-        column: 'test-time-zone',
-        operator: FilterOperator.Equals,
-        value: 'Europe/Berlin'
+        filterSql: `"test-time-zone" = 'Europe/Berlin'`
       }
     ])
   })
@@ -159,12 +156,10 @@ describe('SimpleFilter', () => {
       fireEvent.click(dom.getByText('Option 1'))
     })
 
-    expect(setFilterMock).toHaveBeenCalledWith([
+    expect(setFilterSqlListMock).toHaveBeenCalledWith([
       {
         id: expect.any(Symbol),
-        column: 'test column',
-        operator: FilterOperator.Equals,
-        value: 'option_1'
+        filterSql: `"test column" = 'option_1'`
       }
     ])
   })

--- a/packages/ui-kit/src/components/SimpleFilter/SimpleFilter.tsx
+++ b/packages/ui-kit/src/components/SimpleFilter/SimpleFilter.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import React, { SyntheticEvent, useEffect, useRef } from 'react'
-import { FilterInput, FilterOperator } from '../../graphql'
 import { getTimeZone, useForwardedRefCallback, withThemeWrapper } from '../../helpers'
 import { useTopValues } from '../../hooks'
 import { Autocomplete } from '../Autocomplete'
@@ -39,7 +38,7 @@ const SimpleFilterComponent = React.forwardRef<HTMLSpanElement, SimpleFilterProp
     const id = useRef(Symbol()).current
     const isStatic = !query
 
-    const { filters, setFilters, dataPool: defaultDataPool } = useFilters()
+    const { filterSqlList, setFilterSqlList, dataPool: defaultDataPool } = useFilters()
     const columnName = query?.columnName ?? columnNameProp
     const log = useLog()
     const {
@@ -57,21 +56,15 @@ const SimpleFilterComponent = React.forwardRef<HTMLSpanElement, SimpleFilterProp
 
     const handleChange = (_: SyntheticEvent<Element, Event>, selectedOption: AutocompleteOption | string | null) => {
       if (selectedOption == null) {
-        const filterList = filters.filter((filter) => filter.id !== id)
-        setFilters(filterList)
+        setFilterSqlList(filterSqlList.filter(({ id }) => id !== id))
         return
       }
+      const filterValue =
+        typeof selectedOption === 'string' ? selectedOption : selectedOption?.value ?? selectedOption?.label ?? ''
 
-      const filter: FilterInput = {
-        column: columnName,
-        operator: FilterOperator.Equals,
-        value:
-          typeof selectedOption === 'string' ? selectedOption : selectedOption?.value ?? selectedOption?.label ?? ''
-      }
-
-      const filterList = filters.filter((filter) => filter.id !== id).concat({ ...filter, id })
-
-      setFilters(filterList)
+      setFilterSqlList((prev) =>
+        prev.filter((filter) => filter.id !== id).concat({ filterSql: `${columnName} = '${filterValue}'`, id })
+      )
     }
 
     const autocompleteOptions = (isStatic ? options : data?.topValues.values) ?? []

--- a/packages/ui-kit/src/components/SimpleFilter/SimpleFilter.tsx
+++ b/packages/ui-kit/src/components/SimpleFilter/SimpleFilter.tsx
@@ -56,7 +56,7 @@ const SimpleFilterComponent = React.forwardRef<HTMLSpanElement, SimpleFilterProp
 
     const handleChange = (_: SyntheticEvent<Element, Event>, selectedOption: AutocompleteOption | string | null) => {
       if (selectedOption == null) {
-        setFilterSqlList(filterSqlList.filter(({ id }) => id !== id))
+        setFilterSqlList(filterSqlList.filter((filter) => filter.id !== id))
         return
       }
       const filterValue =

--- a/packages/ui-kit/src/components/SimpleFilter/SimpleFilter.tsx
+++ b/packages/ui-kit/src/components/SimpleFilter/SimpleFilter.tsx
@@ -62,9 +62,11 @@ const SimpleFilterComponent = React.forwardRef<HTMLSpanElement, SimpleFilterProp
       const filterValue =
         typeof selectedOption === 'string' ? selectedOption : selectedOption?.value ?? selectedOption?.label ?? ''
 
-      setFilterSqlList((prev) =>
-        prev.filter((filter) => filter.id !== id).concat({ filterSql: `${columnName} = '${filterValue}'`, id })
-      )
+      const filterSqlListResult = filterSqlList
+        .filter((filter) => filter.id !== id)
+        .concat({ filterSql: `"${columnName}" = '${filterValue}'`, id })
+
+      setFilterSqlList(filterSqlListResult)
     }
 
     const autocompleteOptions = (isStatic ? options : data?.topValues.values) ?? []

--- a/packages/ui-kit/src/components/TimeSeries/TimeSeries.stories.tsx
+++ b/packages/ui-kit/src/components/TimeSeries/TimeSeries.stories.tsx
@@ -341,3 +341,24 @@ export const ErrorStory: Story = {
   },
   render: (args) => <TimeSeries {...args} />
 }
+
+export const FilterSqlStory: Story = {
+  name: 'FilterSql',
+  args: {
+    query: {
+      filterSql: "taco_name = 'Chorizo'",
+      metric: {
+        count: {
+          dataPool: {
+            name: 'TacoSoft Demo Data'
+          }
+        }
+      },
+      timeRange: {
+        relative: RelativeTimeRange.LastNDays,
+        n: 7
+      }
+    }
+  },
+  render: (args) => <TimeSeries {...args} />
+}

--- a/packages/ui-kit/src/components/shared.types.ts
+++ b/packages/ui-kit/src/components/shared.types.ts
@@ -142,6 +142,9 @@ export interface ChartQueryProps extends QueryProps {
    * */
   metric?: string | DeepPartial<MetricInput>
 
-  /** Filters that the chart will respond to */
+  /** @deprecated Filters that the chart will respond to, this prop is deprecated, use `filterSql` instead */
   filters?: FilterInput[]
+
+  /** SQL Filter that the chart will respond to. */
+  filterSql?: string
 }

--- a/packages/ui-kit/src/hooks/useCounter/useCounter.ts
+++ b/packages/ui-kit/src/hooks/useCounter/useCounter.ts
@@ -20,6 +20,7 @@ export const useCounter = (props: CounterQueryProps): UseQueryProps<CounterQuery
     propelApiUrl,
     timeRange: timeRangeProp,
     filters: filtersFromProp,
+    filterSql: filterSqlFromProp,
     refetchInterval,
     retry,
     enabled: enabledProp = true,
@@ -39,9 +40,17 @@ export const useCounter = (props: CounterQueryProps): UseQueryProps<CounterQuery
   // Get access token first from props, then if it is not provided via prop get it from provider
   const accessToken = accessTokenFromProp ?? accessTokenFromProvider
 
-  const { filters: filtersFromProvider, timeRange: timeRangeFromProvider, dataPool: defaultDataPool } = useFilters()
+  const {
+    filters: filtersFromProvider,
+    timeRange: timeRangeFromProvider,
+    dataPool: defaultDataPool,
+    filterSql: filterSqlFromProvider
+  } = useFilters()
 
-  const filters = filtersFromProp ?? filtersFromProvider
+  const filterSql = filterSqlFromProp ?? filterSqlFromProvider
+
+  // Only use filters if filterSql is not provided
+  const filters = filterSql != null ? filtersFromProp ?? filtersFromProvider : []
 
   const timeRange =
     timeRangeFromProvider != null || timeRangeProp != null
@@ -61,6 +70,7 @@ export const useCounter = (props: CounterQueryProps): UseQueryProps<CounterQuery
   const metricInput = typeof metric === 'string' ? { metricName: metric } : { metric: metric as MetricInput }
 
   const withTimeRange: Partial<{ timeRange: TimeRangeInput }> = timeRange != null ? { timeRange: { ...timeRange } } : {}
+  const withFilters = filters.length > 0 ? { filters } : {}
 
   /**
    * @hook react-query wrapper
@@ -82,7 +92,8 @@ export const useCounter = (props: CounterQueryProps): UseQueryProps<CounterQuery
         ...metricInput,
         timeZone: getTimeZone(timeZone),
         ...withTimeRange,
-        filters
+        ...withFilters,
+        filterSql
       }
     },
     {

--- a/packages/ui-kit/src/hooks/useDataGrid/useDataGrid.ts
+++ b/packages/ui-kit/src/hooks/useDataGrid/useDataGrid.ts
@@ -21,7 +21,8 @@ export const useDataGrid = (props: DataGridQueryProps): UseQueryProps<DataGridQu
     timeRange: timeRangeProp,
     timeZone,
     columns,
-    filters: filtersProp,
+    filters: filtersFromProp,
+    filterSql: filterSqlFromProp,
     dataPool: dataPoolProp,
     orderByColumn,
     sort = Sort.Desc,
@@ -48,7 +49,8 @@ export const useDataGrid = (props: DataGridQueryProps): UseQueryProps<DataGridQu
   const {
     filters: filtersFromProvider,
     timeRange: timeRangeFromProvider,
-    dataPool: dataPoolFromProvider
+    dataPool: dataPoolFromProvider,
+    filterSql: filterSqlFromProvider
   } = useFilters()
 
   const dataPool = dataPoolProp ?? dataPoolFromProvider
@@ -59,7 +61,11 @@ export const useDataGrid = (props: DataGridQueryProps): UseQueryProps<DataGridQu
     timeRangeFromProvider != null || timeRangeProp != null
       ? { ...(timeRangeFromProvider ?? {}), ...(timeRangeProp ?? {}) }
       : null
-  const filters = filtersProp ?? filtersFromProvider
+
+  const filterSql = filterSqlFromProp ?? filterSqlFromProvider
+
+  // Only use filters if filterSql is not provided
+  const filters = filterSql != null ? filtersFromProp ?? filtersFromProvider : []
 
   // Get access token first from props, then if it is not provided via prop get it from provider
   const accessToken = accessTokenFromProp ?? accessTokenFromProvider
@@ -72,6 +78,7 @@ export const useDataGrid = (props: DataGridQueryProps): UseQueryProps<DataGridQu
   }
 
   const withTimeRange: Partial<{ timeRange: TimeRangeInput }> = timeRange != null ? { timeRange: { ...timeRange } } : {}
+  const withFilters = filters.length > 0 ? { filters } : {}
 
   const dataPoolInput = dataPool?.name != null ? { name: dataPool.name } : { id: dataPool?.id ?? '' }
 
@@ -94,7 +101,7 @@ export const useDataGrid = (props: DataGridQueryProps): UseQueryProps<DataGridQu
       dataGridInput: {
         columns: isAllColumns ? fetchedColumns ?? [] : columns ?? [],
         dataPool: dataPoolInput,
-        filters: filters ?? [],
+        ...withFilters,
         ...withTimeRange,
         timeZone,
         orderByColumn,
@@ -102,7 +109,8 @@ export const useDataGrid = (props: DataGridQueryProps): UseQueryProps<DataGridQu
         first,
         last,
         after,
-        before
+        before,
+        filterSql
       }
     },
     {

--- a/packages/ui-kit/src/hooks/useTimeSeries/useTimeSeries.ts
+++ b/packages/ui-kit/src/hooks/useTimeSeries/useTimeSeries.ts
@@ -28,6 +28,7 @@ export const useTimeSeries = (props: TimeSeriesQueryProps): UseQueryProps<TimeSe
     timeRange: timeRangeProp,
     granularity: granularityProp,
     filters: filtersFromProp,
+    filterSql: filterSqlFromProp,
     refetchInterval,
     enabled: enabledProp = true,
     retry,
@@ -51,10 +52,14 @@ export const useTimeSeries = (props: TimeSeriesQueryProps): UseQueryProps<TimeSe
     filters: filtersFromProvider,
     timeRange: timeRangeFromProvider,
     granularity: granularityFromProvider,
-    dataPool: defaultDataPool
+    dataPool: defaultDataPool,
+    filterSql: filterSqlFromProvider
   } = useFilters()
 
-  const filters = filtersFromProp ?? filtersFromProvider
+  const filterSql = filterSqlFromProp ?? filterSqlFromProvider
+
+  // Only use filters if filterSql is not provided
+  const filters = filterSql != null ? filtersFromProp ?? filtersFromProvider : []
 
   const timeRange =
     timeRangeFromProvider != null || timeRangeProp != null
@@ -77,6 +82,7 @@ export const useTimeSeries = (props: TimeSeriesQueryProps): UseQueryProps<TimeSe
 
   const withTimeRange: Partial<{ timeRange: TimeRangeInput }> = timeRange != null ? { timeRange: { ...timeRange } } : {}
   const withGroupBy: Partial<{ groupBy: string[] }> = groupBy != null ? { groupBy } : {}
+  const withFilters = filters.length > 0 ? { filters } : {}
 
   /**
    * @hook react-query wrapper
@@ -99,8 +105,9 @@ export const useTimeSeries = (props: TimeSeriesQueryProps): UseQueryProps<TimeSe
         timeZone,
         ...withTimeRange,
         granularity: granularity as TimeSeriesGranularity,
-        filters,
-        ...withGroupBy
+        ...withFilters,
+        ...withGroupBy,
+        filterSql
       }
     },
     {


### PR DESCRIPTION
## Description of changes

This PR deprecates `filters` query prop and add support for `filterSql`

## Checklist

Before merging to main:

- [ ] Tests
- [ ] Manually tested in React apps
- [ ] Changesets
- [ ] Approved
