### PR TITLE
Fix styling precedence issue

### DIFF
--- a/.changeset/five-bees-compete.md
+++ b/.changeset/five-bees-compete.md
@@ -1,0 +1,5 @@
+---
+'@propeldata/ui-kit': patch
+---
+
+Fix style precedence issue

--- a/packages/ui-kit/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/ui-kit/src/components/ThemeProvider/ThemeProvider.tsx
@@ -166,10 +166,6 @@ export const useSetupTheme = <T extends ChartVariant>({
       return
     }
 
-    if (!componentContainer.classList.contains(themes['propel-themes'])) {
-      componentContainer.classList.add(themes['propel-themes'])
-    }
-
     if (context) {
       let componentColors = colors
 


### PR DESCRIPTION
## Description of changes

This PR fixes an issue where ThemeProvider's `propel-theme` was taking precedence over component specific styles

## Checklist

Before merging to main:

- [ ] Tests
- [ ] Manually tested in React apps
- [ ] Changesets
- [ ] Approved
